### PR TITLE
Fix workflow to run build label job on a PR only

### DIFF
--- a/.github/workflows/test-measure.yml
+++ b/.github/workflows/test-measure.yml
@@ -255,6 +255,7 @@ jobs:
           CI: true
 
       - name: Comment on PR with build status
+        if: ${{ github.event_name }} == 'pull_request'
         uses: actions/github-script@v6
         with:
           script: |


### PR DESCRIPTION
## Description

- Only run PR label job if it's a PR.

## Technical Details

<!-- Any technical details that should be explained or mentioned to the reviewers. -->

## Checklist

<!--
If the ticket you worked on had any checklist, include that here and mark items that are covered in this PR. Else, create a checklist of all the items this PR covers.

Example:
- [ ] Fix incorrect meta key value for the Contact block.
- [ ] Fix footer button alignment issue.
-->

## Screenshots

<!-- Add screenshots or screen recordings if applicable and required. -->

## To-do

<!-- Mention anything that needs to be done after this PR as a follow-up or if anything is left uncovered. -->

## Fixes/Covers issue

<!-- Add the issue number which the PR is intended to be for. -->
Fixes #

<!-- After you're done creating the PR, assign the PR to yourself and assign reviewers for the PR. If unsure about whom to ask for a review, leave blank and ping on the project-specific channel. -->
