### PR TITLE
Update script to redirect stdout to /dev/null

### DIFF
--- a/bin/git-init.sh
+++ b/bin/git-init.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-# check if git is initialized already
 if [ -d .git ]; then
-	echo "Git is already initialized"
 	exit 0
 fi
 
-git init
-git add --all .
-git commit -m "Initialize project using rtCamp/theme-elementary"
+{
+	git init
+	git add --all .
+	git commit -m "Initialize project using rtCamp/theme-elementary"
+} &> /dev/null


### PR DESCRIPTION
## Description

When a user initializes the theme for the first time, there is so much output from `git init` and related commands. This PR aims to redirect that standard output to the `/dev/null`.

Lean more about `/dev/null` file [here](https://www.digitalocean.com/community/tutorials/dev-null-in-linux).