### PR TITLE
Update Gutenberg packages after v15.3.1 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 				"@wordpress/env": "5.13.0",
 				"@wordpress/eslint-plugin": "14.1.0",
 				"@wordpress/jest-preset-default": "10.9.0",
-				"@wordpress/scripts": "25.5.0",
+				"@wordpress/scripts": "25.5.1",
 				"browserslist": "4.21.5",
 				"cross-env": "7.0.3",
 				"css-minimizer-webpack-plugin": "4.2.2",
@@ -5574,9 +5574,9 @@
 			}
 		},
 		"node_modules/@wordpress/scripts": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-25.5.0.tgz",
-			"integrity": "sha512-Q4hy4R4PLhx+VOcwbG4CEvyEhEC8SI8tALjmblkYrApVgxTV/9MQPIqMHtHW0Gbh7/jSlkNBmGOlvo9m7W4Icg==",
+			"version": "25.5.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-25.5.1.tgz",
+			"integrity": "sha512-tQiOokRzjZnBE5TIsl5LVJGtsRFHS0IiT54+ERJaF7TZcAlCZhF5pI+sSMPpJunbtwzI2n02iq7I/uaDS5BiFQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/core": "^7.16.0",
@@ -28507,9 +28507,9 @@
 			"requires": {}
 		},
 		"@wordpress/scripts": {
-			"version": "25.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-25.5.0.tgz",
-			"integrity": "sha512-Q4hy4R4PLhx+VOcwbG4CEvyEhEC8SI8tALjmblkYrApVgxTV/9MQPIqMHtHW0Gbh7/jSlkNBmGOlvo9m7W4Icg==",
+			"version": "25.5.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-25.5.1.tgz",
+			"integrity": "sha512-tQiOokRzjZnBE5TIsl5LVJGtsRFHS0IiT54+ERJaF7TZcAlCZhF5pI+sSMPpJunbtwzI2n02iq7I/uaDS5BiFQ==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.16.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"@wordpress/env": "5.13.0",
 		"@wordpress/eslint-plugin": "14.1.0",
 		"@wordpress/jest-preset-default": "10.9.0",
-		"@wordpress/scripts": "25.5.0",
+		"@wordpress/scripts": "25.5.1",
 		"browserslist": "4.21.5",
 		"cross-env": "7.0.3",
 		"css-minimizer-webpack-plugin": "4.2.2",


### PR DESCRIPTION
**Following packages were updated:**<br/><br/>1. [@wordpress/scripts@25.5.1](https://www.npmjs.com/package/@wordpress/scripts/v/25.5.1)<br>