### PR TITLE
Add release.yml

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,5 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - dependabot-preview


### PR DESCRIPTION
## Description

- Exclude `dependabot` PRs from the release changelog.

ref: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes