### PR TITLE
Set dependabot  interval to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: github-actions
     directory: '/'
     schedule:
-      interval: daily
+      interval: monthly
       time: '00:00'
       timezone: 'Asia/Calcutta'
     open-pull-requests-limit: 10
@@ -14,7 +14,7 @@ updates:
   - package-ecosystem: npm
     directory: '/'
     schedule:
-      interval: daily
+      interval: monthly
       time: '00:00'
       timezone: 'Asia/Calcutta'
     open-pull-requests-limit: 10
@@ -29,7 +29,7 @@ updates:
   - package-ecosystem: composer
     directory: '/'
     schedule:
-      interval: daily
+      interval: monthly
       time: '00:00'
       timezone: 'Asia/Calcutta'
     open-pull-requests-limit: 10


### PR DESCRIPTION
- Update dependabot config to raise PRs monthly instead of daily.