### PR TITLE
Fixed the PHPCS issues for WP 6.6

### DIFF
--- a/inc/classes/class-assets.php
+++ b/inc/classes/class-assets.php
@@ -24,7 +24,6 @@ class Assets {
 	protected function __construct() {
 		// Setup hooks.
 		$this->setup_hooks();
-
 	}
 
 	/**
@@ -170,5 +169,4 @@ class Assets {
 	public function enqueue_assets() {
 		wp_enqueue_style( 'elementary-theme-styles' );
 	}
-
 }

--- a/inc/traits/trait-singleton.php
+++ b/inc/traits/trait-singleton.php
@@ -59,7 +59,7 @@ trait Singleton {
 		 *
 		 * @var array
 		 */
-		static $instance = array();
+		static $instance = [];
 
 		/**
 		 * If this trait is implemented in a class which has multiple

--- a/inc/traits/trait-singleton.php
+++ b/inc/traits/trait-singleton.php
@@ -59,7 +59,7 @@ trait Singleton {
 		 *
 		 * @var array
 		 */
-		static $instance = [];
+		static $instance = array();
 
 		/**
 		 * If this trait is implemented in a class which has multiple
@@ -83,7 +83,5 @@ trait Singleton {
 		}
 
 		return $instance[ $called_class ];
-
 	}
-
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -37,7 +37,10 @@
 	#############################################################################
 	-->
 
-	<rule ref="WordPress"/>
+	<rule ref="WordPress">
+		<!-- Excluding sniff to allow shorthand array syntax usage. -->
+		<exclude name="Universal.Arrays.DisallowShortArraySyntax.Found" />
+	</rule>
 
 
 	<!--
@@ -135,10 +138,5 @@
 	<exclude-pattern>includes/polyfills/mbstring.php</exclude-pattern>
 	<exclude-pattern>tests/phpstan/*</exclude-pattern>
 	<exclude-pattern>tests/phpunit/includes/MarkupComparison.php</exclude-pattern>
-
-	<!-- Exclude the following sniffs -->
-	<rule ref="WordPress">
-		<exclude name="Universal.Arrays.DisallowShortArraySyntax.Found" />
-	</rule>
 
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -136,4 +136,9 @@
 	<exclude-pattern>tests/phpstan/*</exclude-pattern>
 	<exclude-pattern>tests/phpunit/includes/MarkupComparison.php</exclude-pattern>
 
+	<!-- Exclude the following sniffs -->
+	<rule ref="WordPress">
+		<exclude name="Universal.Arrays.DisallowShortArraySyntax.Found" />
+	</rule>
+
 </ruleset>


### PR DESCRIPTION


## Description

This PR addresses the PHPCS issues which were present in the code after the updation to WordPress 6.6. Following the coding standards followed in the organization, this PR also adds exception for a PHPCS sniff for the usage of shorthand array syntax.

## Technical Details

- Updated `phcps.xml` to exclude the sniff `Universal.Arrays.DisallowShortArraySyntax.Found`
- Resolved the error `PSR2.Methods.FunctionClosingBrace.SpacingBeforeClose` from the following two files:
   - inc/traits/trait-singleton.php
   - inc/classes/class-assets.php
- Resolved the error `PSR2.Classes.ClassDeclaration.CloseBraceAfterBody` from the following two files:
   - inc/traits/trait-singleton.php
   - inc/classes/class-assets.php

## Checklist

<!--
If the ticket you worked on had any checklist, include that here and mark items that are covered in this PR. Else, create a checklist of all the items this PR covers.

Example:
- [ ] Fix incorrect meta key value for the Contact block.
- [ ] Fix footer button alignment issue.
-->
- [x] Update the phpcs.xml file
- [x] Fix the PHPCS issues in the remaining codebase 

## Fixes/Covers issue

<!-- Add the issue number which the PR is intended to be for. -->
Fixes #468 

<!-- After you're done creating the PR, assign the PR to yourself and assign reviewers for the PR. If unsure about whom to ask for a review, leave blank and ping on the project-specific channel. -->
