### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-measure.yml
+++ b/.github/workflows/test-measure.yml
@@ -10,6 +10,9 @@ on:
       - synchronize
       - ready_for_review
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/rtCamp/theme-elementary/security/code-scanning/7](https://github.com/rtCamp/theme-elementary/security/code-scanning/7)

To fix the problem, we should explicitly define restricted GITHUB_TOKEN permissions in the workflow. The least-privilege set needed for this workflow, based on the visible jobs, is read access to the repository contents so that `actions/checkout` and subsequent build commands work. We can set this once at the workflow root so it applies to all jobs, unless a specific job requires broader permissions later and overrides it.

The best single change is to add a `permissions:` block near the top of `.github/workflows/test-measure.yml`, at the root level (sibling to `on:` and `concurrency:`), specifying `contents: read`. This documents that the workflow only requires read access to repository contents and ensures it remains limited even if organization defaults are broader. No changes are required within individual jobs, and no additional imports or dependencies are needed.

Concretely:
- Edit `.github/workflows/test-measure.yml`.
- After the `on:` block (lines 3–11) and before `concurrency:` (line 13), insert:

```yaml
permissions:
  contents: read
```

This will satisfy CodeQL’s requirement and adhere to the principle of least privilege without altering existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
