### PR TITLE
Update: npm dependencies to latest compatible versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,23 +9,23 @@
 			"version": "1.0.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/interactivity": "6.39.0"
+				"@wordpress/interactivity": "6.40.0"
 			},
 			"devDependencies": {
 				"@babel/core": "7.29.0",
-				"@wordpress/babel-preset-default": "8.39.0",
-				"@wordpress/browserslist-config": "6.39.0",
-				"@wordpress/env": "10.39.0",
-				"@wordpress/eslint-plugin": "24.1.0",
-				"@wordpress/jest-preset-default": "12.39.0",
-				"@wordpress/scripts": "31.4.0",
+				"@wordpress/babel-preset-default": "8.40.0",
+				"@wordpress/browserslist-config": "6.40.0",
+				"@wordpress/env": "^10.39.0",
+				"@wordpress/eslint-plugin": "24.2.0",
+				"@wordpress/jest-preset-default": "12.40.0",
+				"@wordpress/scripts": "31.5.0",
 				"browserslist": "4.28.1",
 				"cross-env": "10.1.0",
 				"css-minimizer-webpack-plugin": "7.0.4",
-				"eslint": "9.39.2",
+				"eslint": "^9.39.0",
 				"eslint-plugin-eslint-comments": "3.2.0",
 				"eslint-plugin-import": "2.32.0",
-				"eslint-plugin-jest": "29.12.1",
+				"eslint-plugin-jest": "29.15.0",
 				"eslint-plugin-react-hooks": "7.0.1",
 				"jest-silent-reporter": "0.6.0",
 				"lint-staged": "16.2.7",
@@ -2044,16 +2044,16 @@
 			"license": "MIT"
 		},
 		"node_modules/@cacheable/memory": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.7.tgz",
-			"integrity": "sha512-RbxnxAMf89Tp1dLhXMS7ceft/PGsDl1Ip7T20z5nZ+pwIAsQ1p2izPjVG69oCLv/jfQ7HDPHTWK0c9rcAWXN3A==",
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.8.tgz",
+			"integrity": "sha512-FvEb29x5wVwu/Kf93IWwsOOEuhHh6dYCJF3vcKLzXc0KXIW181AOzv6ceT4ZpBHDvAfG60eqb+ekmrnLHIy+jw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@cacheable/utils": "^2.3.3",
-				"@keyv/bigmap": "^1.3.0",
-				"hookified": "^1.14.0",
-				"keyv": "^5.5.5"
+				"@cacheable/utils": "^2.4.0",
+				"@keyv/bigmap": "^1.3.1",
+				"hookified": "^1.15.1",
+				"keyv": "^5.6.0"
 			}
 		},
 		"node_modules/@cacheable/memory/node_modules/@keyv/bigmap": {
@@ -2084,13 +2084,13 @@
 			}
 		},
 		"node_modules/@cacheable/utils": {
-			"version": "2.3.4",
-			"resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.3.4.tgz",
-			"integrity": "sha512-knwKUJEYgIfwShABS1BX6JyJJTglAFcEU7EXqzTdiGCXur4voqkiJkdgZIQtWNFhynzDWERcTYv/sETMu3uJWA==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.4.0.tgz",
+			"integrity": "sha512-PeMMsqjVq+bF0WBsxFBxr/WozBJiZKY0rUojuaCoIaKnEl3Ju1wfEwS+SV1DU/cSe8fqHIPiYJFif8T3MVt4cQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"hashery": "^1.3.0",
+				"hashery": "^1.5.0",
 				"keyv": "^5.6.0"
 			}
 		},
@@ -2200,9 +2200,9 @@
 			}
 		},
 		"node_modules/@csstools/css-syntax-patches-for-csstree": {
-			"version": "1.0.28",
-			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.28.tgz",
-			"integrity": "sha512-1NRf1CUBjnr3K7hu8BLxjQrKCxEe8FP/xmPTenAxCRZWVLbmGotkFvG9mfNpjA6k7Bw1bw4BilZq9cu19RA5pg==",
+			"version": "1.0.29",
+			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.29.tgz",
+			"integrity": "sha512-jx9GjkkP5YHuTmko2eWAvpPnb0mB4mGRr2U7XwVNwevm8nlpobZEVk+GNmiYMk2VuA75v+plfXWyroWKmICZXg==",
 			"dev": true,
 			"funding": [
 				{
@@ -2502,9 +2502,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@eslint/js": {
-			"version": "9.39.2",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
-			"integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
+			"version": "9.39.3",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.3.tgz",
+			"integrity": "sha512-1B1VkCq6FuUNlQvlBYb+1jDu/gV297TIs/OeiaSR9l1H27SVW55ONE1e1Vp16NqP683+xEGzxYtv4XCiDPaQiw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4697,14 +4697,14 @@
 			}
 		},
 		"node_modules/@jsonjoy.com/fs-core": {
-			"version": "4.56.10",
-			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.56.10.tgz",
-			"integrity": "sha512-PyAEA/3cnHhsGcdY+AmIU+ZPqTuZkDhCXQ2wkXypdLitSpd6d5Ivxhnq4wa2ETRWFVJGabYynBWxIijOswSmOw==",
+			"version": "4.56.11",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.56.11.tgz",
+			"integrity": "sha512-wThHjzUp01ImIjfCwhs+UnFkeGPFAymwLEkOtenHewaKe2pTP12p6r1UuwikA9NEvNf9Vlck92r8fb8n/MWM5w==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@jsonjoy.com/fs-node-builtins": "4.56.10",
-				"@jsonjoy.com/fs-node-utils": "4.56.10",
+				"@jsonjoy.com/fs-node-builtins": "4.56.11",
+				"@jsonjoy.com/fs-node-utils": "4.56.11",
 				"thingies": "^2.5.0"
 			},
 			"engines": {
@@ -4719,15 +4719,15 @@
 			}
 		},
 		"node_modules/@jsonjoy.com/fs-fsa": {
-			"version": "4.56.10",
-			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.56.10.tgz",
-			"integrity": "sha512-/FVK63ysNzTPOnCCcPoPHt77TOmachdMS422txM4KhxddLdbW1fIbFMYH0AM0ow/YchCyS5gqEjKLNyv71j/5Q==",
+			"version": "4.56.11",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.56.11.tgz",
+			"integrity": "sha512-ZYlF3XbMayyp97xEN8ZvYutU99PCHjM64mMZvnCseXkCJXJDVLAwlF8Q/7q/xiWQRsv3pQBj1WXHd9eEyYcaCQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@jsonjoy.com/fs-core": "4.56.10",
-				"@jsonjoy.com/fs-node-builtins": "4.56.10",
-				"@jsonjoy.com/fs-node-utils": "4.56.10",
+				"@jsonjoy.com/fs-core": "4.56.11",
+				"@jsonjoy.com/fs-node-builtins": "4.56.11",
+				"@jsonjoy.com/fs-node-utils": "4.56.11",
 				"thingies": "^2.5.0"
 			},
 			"engines": {
@@ -4742,17 +4742,17 @@
 			}
 		},
 		"node_modules/@jsonjoy.com/fs-node": {
-			"version": "4.56.10",
-			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.56.10.tgz",
-			"integrity": "sha512-7R4Gv3tkUdW3dXfXiOkqxkElxKNVdd8BDOWC0/dbERd0pXpPY+s2s1Mino+aTvkGrFPiY+mmVxA7zhskm4Ue4Q==",
+			"version": "4.56.11",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.56.11.tgz",
+			"integrity": "sha512-D65YrnP6wRuZyEWoSFnBJSr5zARVpVBGctnhie4rCsMuGXNzX7IHKaOt85/Aj7SSoG1N2+/xlNjWmkLvZ2H3Tg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@jsonjoy.com/fs-core": "4.56.10",
-				"@jsonjoy.com/fs-node-builtins": "4.56.10",
-				"@jsonjoy.com/fs-node-utils": "4.56.10",
-				"@jsonjoy.com/fs-print": "4.56.10",
-				"@jsonjoy.com/fs-snapshot": "4.56.10",
+				"@jsonjoy.com/fs-core": "4.56.11",
+				"@jsonjoy.com/fs-node-builtins": "4.56.11",
+				"@jsonjoy.com/fs-node-utils": "4.56.11",
+				"@jsonjoy.com/fs-print": "4.56.11",
+				"@jsonjoy.com/fs-snapshot": "4.56.11",
 				"glob-to-regex.js": "^1.0.0",
 				"thingies": "^2.5.0"
 			},
@@ -4768,9 +4768,9 @@
 			}
 		},
 		"node_modules/@jsonjoy.com/fs-node-builtins": {
-			"version": "4.56.10",
-			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.56.10.tgz",
-			"integrity": "sha512-uUnKz8R0YJyKq5jXpZtkGV9U0pJDt8hmYcLRrPjROheIfjMXsz82kXMgAA/qNg0wrZ1Kv+hrg7azqEZx6XZCVw==",
+			"version": "4.56.11",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.56.11.tgz",
+			"integrity": "sha512-CNmt3a0zMCIhniFLXtzPWuUxXFU+U+2VyQiIrgt/rRVeEJNrMQUABaRbVxR0Ouw1LyR9RjaEkPM6nYpED+y43A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -4785,15 +4785,15 @@
 			}
 		},
 		"node_modules/@jsonjoy.com/fs-node-to-fsa": {
-			"version": "4.56.10",
-			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.56.10.tgz",
-			"integrity": "sha512-oH+O6Y4lhn9NyG6aEoFwIBNKZeYy66toP5LJcDOMBgL99BKQMUf/zWJspdRhMdn/3hbzQsZ8EHHsuekbFLGUWw==",
+			"version": "4.56.11",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.56.11.tgz",
+			"integrity": "sha512-5OzGdvJDgZVo+xXWEYo72u81zpOWlxlbG4d4nL+hSiW+LKlua/dldNgPrpWxtvhgyntmdFQad2UTxFyGjJAGhA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@jsonjoy.com/fs-fsa": "4.56.10",
-				"@jsonjoy.com/fs-node-builtins": "4.56.10",
-				"@jsonjoy.com/fs-node-utils": "4.56.10"
+				"@jsonjoy.com/fs-fsa": "4.56.11",
+				"@jsonjoy.com/fs-node-builtins": "4.56.11",
+				"@jsonjoy.com/fs-node-utils": "4.56.11"
 			},
 			"engines": {
 				"node": ">=10.0"
@@ -4807,13 +4807,13 @@
 			}
 		},
 		"node_modules/@jsonjoy.com/fs-node-utils": {
-			"version": "4.56.10",
-			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.56.10.tgz",
-			"integrity": "sha512-8EuPBgVI2aDPwFdaNQeNpHsyqPi3rr+85tMNG/lHvQLiVjzoZsvxA//Xd8aB567LUhy4QS03ptT+unkD/DIsNg==",
+			"version": "4.56.11",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.56.11.tgz",
+			"integrity": "sha512-JADOZFDA3wRfsuxkT0+MYc4F9hJO2PYDaY66kRTG6NqGX3+bqmKu66YFYAbII/tEmQWPZeHoClUB23rtQM9UPg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@jsonjoy.com/fs-node-builtins": "4.56.10"
+				"@jsonjoy.com/fs-node-builtins": "4.56.11"
 			},
 			"engines": {
 				"node": ">=10.0"
@@ -4827,13 +4827,13 @@
 			}
 		},
 		"node_modules/@jsonjoy.com/fs-print": {
-			"version": "4.56.10",
-			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.56.10.tgz",
-			"integrity": "sha512-JW4fp5mAYepzFsSGrQ48ep8FXxpg4niFWHdF78wDrFGof7F3tKDJln72QFDEn/27M1yHd4v7sKHHVPh78aWcEw==",
+			"version": "4.56.11",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.56.11.tgz",
+			"integrity": "sha512-rnaKRgCRIn8JGTjxhS0JPE38YM3Pj/H7SW4/tglhIPbfKEkky7dpPayNKV2qy25SZSL15oFVgH/62dMZ/z7cyA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@jsonjoy.com/fs-node-utils": "4.56.10",
+				"@jsonjoy.com/fs-node-utils": "4.56.11",
 				"tree-dump": "^1.1.0"
 			},
 			"engines": {
@@ -4848,14 +4848,14 @@
 			}
 		},
 		"node_modules/@jsonjoy.com/fs-snapshot": {
-			"version": "4.56.10",
-			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.56.10.tgz",
-			"integrity": "sha512-DkR6l5fj7+qj0+fVKm/OOXMGfDFCGXLfyHkORH3DF8hxkpDgIHbhf/DwncBMs2igu/ST7OEkexn1gIqoU6Y+9g==",
+			"version": "4.56.11",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.56.11.tgz",
+			"integrity": "sha512-IIldPX+cIRQuUol9fQzSS3hqyECxVpYMJQMqdU3dCKZFRzEl1rkIkw4P6y7Oh493sI7YdxZlKr/yWdzEWZ1wGQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@jsonjoy.com/buffers": "^17.65.0",
-				"@jsonjoy.com/fs-node-utils": "4.56.10",
+				"@jsonjoy.com/fs-node-utils": "4.56.11",
 				"@jsonjoy.com/json-pack": "^17.65.0",
 				"@jsonjoy.com/util": "^17.65.0"
 			},
@@ -6845,13 +6845,13 @@
 			}
 		},
 		"node_modules/@php-wasm/cli-util": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/cli-util/-/cli-util-3.1.2.tgz",
-			"integrity": "sha512-pUUbACHsrFc2QSNqKEhiFhwCD1dbroH8/14hQYW+lcgswG10sqMMgfmk7FBp61jTntXdweYhNFjcoIOMV3h0OA==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@php-wasm/cli-util/-/cli-util-3.1.4.tgz",
+			"integrity": "sha512-SVJBkvwT9FMM9AhVgjIwXh1KJZaEl/IvULIXKKSfmdqhk9SLpqmyJWw/WsibDzsj1FtcUHO+MmI5t7MVi5OioA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/util": "3.1.2",
+				"@php-wasm/util": "3.1.4",
 				"fast-xml-parser": "^5.3.4",
 				"jsonc-parser": "3.3.1"
 			},
@@ -6860,37 +6860,14 @@
 				"npm": ">=10.2.3"
 			}
 		},
-		"node_modules/@php-wasm/fs-journal": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/fs-journal/-/fs-journal-3.1.2.tgz",
-			"integrity": "sha512-8e8lz/IG6EA8h2/lGSOijdhemaABTt45zohhMYYSjuCu5fV24p+6rGkK7I+dGqxaY4cO2IDjU4XE+HRnodW88g==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/logger": "3.1.2",
-				"@php-wasm/node": "3.1.2",
-				"@php-wasm/universal": "3.1.2",
-				"@php-wasm/util": "3.1.2",
-				"express": "4.22.0",
-				"fs-ext-extra-prebuilt": "2.2.7",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3",
-				"yargs": "17.7.2"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
 		"node_modules/@php-wasm/logger": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.2.tgz",
-			"integrity": "sha512-VD1SbuTL24LgbkPaQCijDzc9V7SSVU5hi+up4yNpHeL8pP8kabIYYSR7PgTfity1Awk6ctW5kUpOhSieD+1Btw==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.4.tgz",
+			"integrity": "sha512-qJADSkoHZIvoLomnyglMcISdfJH+9fZ+4YZ7N/vJrfo0vHp/51nOmKa38eKmONUGInAgKHIJ5LZ9b73dYtDygA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/node-polyfills": "3.1.2"
+				"@php-wasm/node-polyfills": "3.1.4"
 			},
 			"engines": {
 				"node": ">=20.10.0",
@@ -6898,27 +6875,30 @@
 			}
 		},
 		"node_modules/@php-wasm/node": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-3.1.2.tgz",
-			"integrity": "sha512-Y/I2nUjo1Aof4irF1cfAxX33Ra5xa2HQcy3HmIXXurqTBE7bZMu5TKvJW7t0cfBLohuaWY1bs8n4nLS1BetuTg==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-3.1.4.tgz",
+			"integrity": "sha512-sDWXq+3ApKDZAVTJRaERRBkzpoiudNcnXz5yk5leeqymCOwNz6F0V+jSndcO0shEbsOTOT6b4J89pdKVSBUVOg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/logger": "3.1.2",
-				"@php-wasm/node-7-4": "3.1.2",
-				"@php-wasm/node-8-0": "3.1.2",
-				"@php-wasm/node-8-1": "3.1.2",
-				"@php-wasm/node-8-2": "3.1.2",
-				"@php-wasm/node-8-3": "3.1.2",
-				"@php-wasm/node-8-4": "3.1.2",
-				"@php-wasm/node-8-5": "3.1.2",
-				"@php-wasm/node-polyfills": "3.1.2",
-				"@php-wasm/universal": "3.1.2",
-				"@php-wasm/util": "3.1.2",
-				"@wp-playground/common": "3.1.2",
+				"@php-wasm/cli-util": "3.1.4",
+				"@php-wasm/logger": "3.1.4",
+				"@php-wasm/node-7-4": "3.1.4",
+				"@php-wasm/node-8-0": "3.1.4",
+				"@php-wasm/node-8-1": "3.1.4",
+				"@php-wasm/node-8-2": "3.1.4",
+				"@php-wasm/node-8-3": "3.1.4",
+				"@php-wasm/node-8-4": "3.1.4",
+				"@php-wasm/node-8-5": "3.1.4",
+				"@php-wasm/node-polyfills": "3.1.4",
+				"@php-wasm/universal": "3.1.4",
+				"@php-wasm/util": "3.1.4",
+				"@wp-playground/common": "3.1.4",
 				"express": "4.22.0",
+				"fast-xml-parser": "^5.3.4",
 				"fs-ext-extra-prebuilt": "2.2.7",
 				"ini": "4.1.2",
+				"jsonc-parser": "3.3.1",
 				"wasm-feature-detect": "1.8.0",
 				"ws": "8.18.3",
 				"yargs": "17.7.2"
@@ -6929,13 +6909,13 @@
 			}
 		},
 		"node_modules/@php-wasm/node-7-4": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-7-4/-/node-7-4-3.1.2.tgz",
-			"integrity": "sha512-n8QjH2/PiJV28Ad9a4jn/3Rq1cVU3bD+8+4aDOyEbhwxl9Qvb6NvSqMER/3KqasH5cvZiZLsMy92+q+CjcIQAA==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-7-4/-/node-7-4-3.1.4.tgz",
+			"integrity": "sha512-iP95JNInGsJdu4Zp/7x3rROpw1bbidq9X2RDwjO6fhCrG+zWifKgg/I2hFAIpYAJeZXAaN4MPyqeihtmLZ204g==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/universal": "3.1.2",
+				"@php-wasm/universal": "3.1.4",
 				"ini": "4.1.2",
 				"wasm-feature-detect": "1.8.0",
 				"ws": "8.18.3"
@@ -6946,13 +6926,13 @@
 			}
 		},
 		"node_modules/@php-wasm/node-8-0": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-0/-/node-8-0-3.1.2.tgz",
-			"integrity": "sha512-sNSk858peKueucrNKAKbZ094XJOsP8AcK+XLM1KjS+VNoT5aVNC5xzZnQhArxCI6lZqkUhvmGqV1DNEdmX/ayA==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-0/-/node-8-0-3.1.4.tgz",
+			"integrity": "sha512-upNChLPNE95Pq1OHsHaZn1o36r0px9Iz2gSPXE+rZO4+C93JFyG24VJAqxh61c7CN+4Y1hudee66X4zCe5BAog==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/universal": "3.1.2",
+				"@php-wasm/universal": "3.1.4",
 				"ini": "4.1.2",
 				"wasm-feature-detect": "1.8.0",
 				"ws": "8.18.3"
@@ -6963,13 +6943,13 @@
 			}
 		},
 		"node_modules/@php-wasm/node-8-1": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-1/-/node-8-1-3.1.2.tgz",
-			"integrity": "sha512-HDfA0+uMhZEMFAeryN/kkCbcuW5Bv11liCuwxxwGdNj21NxRVFoDhYYm1FKyFPTbZWHemSJXkpZgyh4g2HfL5w==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-1/-/node-8-1-3.1.4.tgz",
+			"integrity": "sha512-JXW3o278v4Rf02SZLxV4g/zDtDxp3KNsv+9Yy1QP7SscfDWe3R7Vo65S2NG7GZItIVcQ8n1KLMqZLCOcDR+tmg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/universal": "3.1.2",
+				"@php-wasm/universal": "3.1.4",
 				"ini": "4.1.2",
 				"wasm-feature-detect": "1.8.0",
 				"ws": "8.18.3"
@@ -6980,13 +6960,13 @@
 			}
 		},
 		"node_modules/@php-wasm/node-8-2": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-2/-/node-8-2-3.1.2.tgz",
-			"integrity": "sha512-+225WZUAf4foAr+DT9ahS7Rna3h7DslI9anrWShR7a8FxAaCUgi0dw4Rh2can2K0/Q+moC3l2OZC93NIhedsuw==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-2/-/node-8-2-3.1.4.tgz",
+			"integrity": "sha512-QRT436IfwQVLpns2dpCsgEuDAh4kS1SRHcaG3cn0ShUpUwxwU/vkGR58uKmXDPGSeLYgMX8ozLZWARUUK8TjCg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/universal": "3.1.2",
+				"@php-wasm/universal": "3.1.4",
 				"ini": "4.1.2",
 				"wasm-feature-detect": "1.8.0",
 				"ws": "8.18.3"
@@ -6997,13 +6977,13 @@
 			}
 		},
 		"node_modules/@php-wasm/node-8-3": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-3/-/node-8-3-3.1.2.tgz",
-			"integrity": "sha512-fRncog0ai610bhzFmSYXq5N3vaVoZNAU0GxhzcKXGsPF4x5o07wViMClyqXpxcqn+KC4RhV4YK5hCGhGvzEvkA==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-3/-/node-8-3-3.1.4.tgz",
+			"integrity": "sha512-l/xUJqKB14PLdvVQAEDYfs8Ne3vcQZ+ixOZre1k+gig6L2M0UZkX+UKf5PtE26Ft3VAquQUSeYgmPrO3A1kdnQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/universal": "3.1.2",
+				"@php-wasm/universal": "3.1.4",
 				"ini": "4.1.2",
 				"wasm-feature-detect": "1.8.0",
 				"ws": "8.18.3"
@@ -7014,13 +6994,13 @@
 			}
 		},
 		"node_modules/@php-wasm/node-8-4": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-4/-/node-8-4-3.1.2.tgz",
-			"integrity": "sha512-3J5tnLJwmmZrX/bHiCA/nbBhMMC58kWhX8v62B2LB+Hx7zq2agSETaga1tk4RzbIrs85noq4tuPUng9yAsSkHw==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-4/-/node-8-4-3.1.4.tgz",
+			"integrity": "sha512-HvxShZ9RjQF+QXDlN44qcRou4okq6JTEHA3EYmqzaJv7V5+Zjn3K3bOaUAWtd9wem+kc4p1RTJ+ZgaMSp+QUVw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/universal": "3.1.2",
+				"@php-wasm/universal": "3.1.4",
 				"ini": "4.1.2",
 				"wasm-feature-detect": "1.8.0",
 				"ws": "8.18.3"
@@ -7031,13 +7011,13 @@
 			}
 		},
 		"node_modules/@php-wasm/node-8-5": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-5/-/node-8-5-3.1.2.tgz",
-			"integrity": "sha512-JAalPcRB4VQd0Iz0BWcPp5DXNsNcw5Rq20XSz4YmlCDkGNJ46DsgGF1ZjptbacFYYGdJGm7mfMoiJuAhuVu1Cw==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-5/-/node-8-5-3.1.4.tgz",
+			"integrity": "sha512-dQWrrA5Wjx0mo3a5COWUjlbCSPM7k+FXJoSnJWBSFQwfQycMEPOWxrRX2Hxtm+i6QXGI5UyJR0SI9cSVIx09RA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/universal": "3.1.2",
+				"@php-wasm/universal": "3.1.4",
 				"ini": "4.1.2",
 				"wasm-feature-detect": "1.8.0",
 				"ws": "8.18.3"
@@ -7048,21 +7028,21 @@
 			}
 		},
 		"node_modules/@php-wasm/node-polyfills": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-polyfills/-/node-polyfills-3.1.2.tgz",
-			"integrity": "sha512-fPKQVX8SEV5wWlAuO+wJeWTt4qf1eA5WVcoS3bS/dCHy437NzrnIZ/caJB8MHgjNRDh+d/QWHS3gDDs0NvYhjQ==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-polyfills/-/node-polyfills-3.1.4.tgz",
+			"integrity": "sha512-7lL50hCUWA7cDl6Q6rWIks4eKbfI/TrDl8GKYf7E56Ep1JNUMFLmzU/nxmPDB9la+fbVhpkL17Tc5izyqK3Y1A==",
 			"dev": true,
 			"license": "GPL-2.0-or-later"
 		},
 		"node_modules/@php-wasm/progress": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.2.tgz",
-			"integrity": "sha512-IND/q2zpLufURpuiQ94w4/Thx6z2I1zkfvGZ7tbThz+kyMuTOrog2Q6f8vL7xL1UI1cGTWCRiUVxzj4EtMvJag==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.4.tgz",
+			"integrity": "sha512-eu9qyfuNJr8Jju2mIqAtP5ovt7lwbduDvjHBbrP/uHicBqCwI6uPK9dGc0qLjQ8ZQ/yJqi+qOpnpUKbk0xIWOw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/logger": "3.1.2",
-				"@php-wasm/node-polyfills": "3.1.2"
+				"@php-wasm/logger": "3.1.4",
+				"@php-wasm/node-polyfills": "3.1.4"
 			},
 			"engines": {
 				"node": ">=20.10.0",
@@ -7070,9 +7050,9 @@
 			}
 		},
 		"node_modules/@php-wasm/scopes": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.1.2.tgz",
-			"integrity": "sha512-M5BO27JMIS2FMifh2Eb2BjWrAmA0h26Q2Sf2gx5gOk64SleMaJNuYxpPC8WdqNru7IDmjZbRoK//OIPscaPhxA==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.1.4.tgz",
+			"integrity": "sha512-+PQToTb2txA0A6450/IbJHotrFVGGAKWsU22hLCvpzcT9Zj1F3NInkkDAMjZ7Na4nofNzyc82ED8MWafwhxFmw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -7081,28 +7061,28 @@
 			}
 		},
 		"node_modules/@php-wasm/stream-compression": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.2.tgz",
-			"integrity": "sha512-nUM7DtBkPF1Y3v9FW1CMG7nJLIDnoH3MKfKON6R/knwDpAExQVOII3K8AZuiVyr4IAiFZwYza8H5bkM+UUmFBg==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.4.tgz",
+			"integrity": "sha512-gr6Y2N7XTW1ceh8yycFE/h7u4hLHWwmyvFwtjfb0U1FWIRerpXzyVwy9Fzlw3D8vgAsMpeM4OZdZ2MWyC8kN1g==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/node-polyfills": "3.1.2",
-				"@php-wasm/util": "3.1.2"
+				"@php-wasm/node-polyfills": "3.1.4",
+				"@php-wasm/util": "3.1.4"
 			}
 		},
 		"node_modules/@php-wasm/universal": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.2.tgz",
-			"integrity": "sha512-rgKyeqBVHZ6bDOwoYg9lUtZxgh7aB+/ryGcL1QEYyr7260bFwVgf8MWNP+211fktLa1yvuvl4dyDepaQiV0sDA==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.4.tgz",
+			"integrity": "sha512-9JWhjHZ3ZwnzqaR7ZuRfGdCvLjxdbg4Ok23PgVjsoMOCoFZWm6LUvR0nfZ7tRuKue8Bgwzzssx6RuwCy7Z5dIQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/logger": "3.1.2",
-				"@php-wasm/node-polyfills": "3.1.2",
-				"@php-wasm/progress": "3.1.2",
-				"@php-wasm/stream-compression": "3.1.2",
-				"@php-wasm/util": "3.1.2",
+				"@php-wasm/logger": "3.1.4",
+				"@php-wasm/node-polyfills": "3.1.4",
+				"@php-wasm/progress": "3.1.4",
+				"@php-wasm/stream-compression": "3.1.4",
+				"@php-wasm/util": "3.1.4",
 				"ini": "4.1.2"
 			},
 			"engines": {
@@ -7111,167 +7091,23 @@
 			}
 		},
 		"node_modules/@php-wasm/util": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.2.tgz",
-			"integrity": "sha512-g22dH4zIQ26hQHRNBfp9csy3W8tDDdyB4G8Euvj6PNxEBsTnY/A6WG1/wLZ3PUED9ULsz/lKKFSiEZo8Hj8B8g==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.4.tgz",
+			"integrity": "sha512-JAJGJAU/D5N/4pAvNEUZaDBZlFVMkjUYR7MAEsm3Dtq8yqsjl4oNRI43zpvdnfzSd6FVf0jOB5AVrC3wfv83yQ==",
 			"dev": true,
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/web": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/web/-/web-3.1.2.tgz",
-			"integrity": "sha512-HV9RKqm3DfOuMlDlC+Q0nxLv8xCf6E5yhatrimJ8fXXLRUTaBzpDbsbwi2eq8qcb6A48Yj25wY8BSpqWSYJYVw==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/fs-journal": "3.1.2",
-				"@php-wasm/logger": "3.1.2",
-				"@php-wasm/universal": "3.1.2",
-				"@php-wasm/util": "3.1.2",
-				"@php-wasm/web-7-4": "3.1.2",
-				"@php-wasm/web-8-0": "3.1.2",
-				"@php-wasm/web-8-1": "3.1.2",
-				"@php-wasm/web-8-2": "3.1.2",
-				"@php-wasm/web-8-3": "3.1.2",
-				"@php-wasm/web-8-4": "3.1.2",
-				"@php-wasm/web-8-5": "3.1.2",
-				"@php-wasm/web-service-worker": "3.1.2",
-				"@wp-playground/common": "3.1.2",
-				"express": "4.22.0",
-				"fs-ext-extra-prebuilt": "2.2.7",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3",
-				"yargs": "17.7.2"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/web-7-4": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/web-7-4/-/web-7-4-3.1.2.tgz",
-			"integrity": "sha512-3Vq1yt7fqEo40PXZFRobxNLTzrDGS8I0ciIQ5XED0/TJh6bnV39T3wmecq1dbDCw/wrCdDK3kdlBUnViUpSQ5g==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.2",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/web-8-0": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/web-8-0/-/web-8-0-3.1.2.tgz",
-			"integrity": "sha512-zKL10GRajDi59Q3wB7AyWNZZaEeikM7HRpHarBBs2UhmTVS93Tyhoj4WsaN5KC3MZlxIV2g6QgXhcJHEyuve+A==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.2",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/web-8-1": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/web-8-1/-/web-8-1-3.1.2.tgz",
-			"integrity": "sha512-zXsiao1+Op0Qkgc4zmrgEzkpON547pTuQdljNlqGKdRcA8l/xhTme7fhm5GsSP/UEQbP3n7PEOjKPAQi8S9wSA==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.2",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/web-8-2": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/web-8-2/-/web-8-2-3.1.2.tgz",
-			"integrity": "sha512-tAgutFkzIwSir7HOnu4IRQLX3uTYArl3wqqlpK/GfIXwyCHSRaq1OTQfh4mq4U3ulCu97MwOHiJBqSDoE5qyrQ==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.2",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/web-8-3": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/web-8-3/-/web-8-3-3.1.2.tgz",
-			"integrity": "sha512-RZLz0XxwkdTy17ijpIPe2iZe1s5ZbEybVIw131jjgLm5bTSuTCwYod7LUNCdRy0QE651g8142Aw5W9iYFnLwfg==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.2",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/web-8-4": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/web-8-4/-/web-8-4-3.1.2.tgz",
-			"integrity": "sha512-v4ujuPNwI1eWBkB9Nzj1+hUKVZaxr/ev7LFA0hi+wOMk4ZVW2hLx1AE7jE2v7L2zADW7JJ2tGP3gK37/TAmpug==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.2",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/web-8-5": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/web-8-5/-/web-8-5-3.1.2.tgz",
-			"integrity": "sha512-XSyTybscwd7CFhTjPMUq02s5WqJE1xwjfIMMut7sT3HzD0TM5wGpbQLS53Vj5XXWUtLgsG19hW/JyREHzR05eQ==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.2",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0"
-			},
 			"engines": {
 				"node": ">=20.10.0",
 				"npm": ">=10.2.3"
 			}
 		},
 		"node_modules/@php-wasm/web-service-worker": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.1.2.tgz",
-			"integrity": "sha512-rZOgdjOBed9EcQwsEVDBpdQVDY30eEAQ+bxEAMB1OrcpXzFPwMdfkVZvxo6fP7DA9qg9Qr/ethRve0O5dNJALA==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.1.4.tgz",
+			"integrity": "sha512-DTJVoz8x5xTPBv3xNGJSmf3tXeYet0CXK0HWX7IRS4Zor3N8kzDLn9si2K61tJ5063P0rczQ/fp/YhNAhQVkkw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/scopes": "3.1.2"
+				"@php-wasm/scopes": "3.1.4"
 			},
 			"engines": {
 				"node": ">=20.10.0",
@@ -7279,19 +7115,21 @@
 			}
 		},
 		"node_modules/@php-wasm/xdebug-bridge": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@php-wasm/xdebug-bridge/-/xdebug-bridge-3.1.2.tgz",
-			"integrity": "sha512-oArlnqIo9YFOro8rdaAPipSfuOht//47XxvpwQbjEvOsJ54WkyNKmxOD1QFqNjj4y9cc3yCaqeYb/xUcn0tp6Q==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@php-wasm/xdebug-bridge/-/xdebug-bridge-3.1.4.tgz",
+			"integrity": "sha512-s6iZjVPUEFp/xhU+kGq2gnSMbZeS+w0TWSdikb+HjBl1Uzh+xAwTGCEey+PsvmRL7VkZ/PLWxwP9xq6GsDQ5YQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/logger": "3.1.2",
-				"@php-wasm/node": "3.1.2",
-				"@php-wasm/universal": "3.1.2",
-				"@wp-playground/common": "3.1.2",
+				"@php-wasm/logger": "3.1.4",
+				"@php-wasm/node": "3.1.4",
+				"@php-wasm/universal": "3.1.4",
+				"@wp-playground/common": "3.1.4",
 				"express": "4.22.0",
+				"fast-xml-parser": "^5.3.4",
 				"fs-ext-extra-prebuilt": "2.2.7",
 				"ini": "4.1.2",
+				"jsonc-parser": "3.3.1",
 				"wasm-feature-detect": "1.8.0",
 				"ws": "8.18.3",
 				"xml2js": "0.6.2",
@@ -7584,32 +7422,6 @@
 				"@opentelemetry/resources": "^1.30.1 || ^2.0.0",
 				"@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.0.0",
 				"@opentelemetry/semantic-conventions": "^1.34.0"
-			}
-		},
-		"node_modules/@sentry/node/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
-		},
-		"node_modules/@sentry/node/node_modules/minimatch": {
-			"version": "9.0.9",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.2"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/@sentry/opentelemetry": {
@@ -8749,45 +8561,6 @@
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
-		"node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "18 || 20 || >=22"
-			}
-		},
-		"node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-			"integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^4.0.2"
-			},
-			"engines": {
-				"node": "18 || 20 || >=22"
-			}
-		},
-		"node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-			"version": "10.2.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-			"integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"brace-expansion": "^5.0.2"
-			},
-			"engines": {
-				"node": "18 || 20 || >=22"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
 			"version": "7.7.4",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -9341,9 +9114,9 @@
 			}
 		},
 		"node_modules/@wordpress/babel-preset-default": {
-			"version": "8.39.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.39.0.tgz",
-			"integrity": "sha512-H5rheT+rrXuPb9+ey5LemC8g4i5uGVndpalboEQHaXVpLII9B283+ZmtQZy1We1RdIyVXD6MB2EtSXt8R4oKuw==",
+			"version": "8.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.40.0.tgz",
+			"integrity": "sha512-UzSwDaxsMarnlfFUmEWW2qvkJy4JupW49uH0JztFobCamQ5QCL71M75zIspIXffiZVjQMBWruR7/+5QTJklewA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -9353,8 +9126,8 @@
 				"@babel/plugin-transform-runtime": "7.25.7",
 				"@babel/preset-env": "7.25.7",
 				"@babel/preset-typescript": "7.25.7",
-				"@wordpress/browserslist-config": "^6.39.0",
-				"@wordpress/warning": "^3.39.0",
+				"@wordpress/browserslist-config": "^6.40.0",
+				"@wordpress/warning": "^3.40.0",
 				"browserslist": "^4.21.10",
 				"core-js": "^3.31.0",
 				"react": "^18.3.0"
@@ -9396,9 +9169,9 @@
 			}
 		},
 		"node_modules/@wordpress/base-styles": {
-			"version": "6.16.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.16.0.tgz",
-			"integrity": "sha512-g8eZCTULM9rdQMTYfp3U+bHjT6wTtyuo8BFE2PCwJmH60Lp6P4qjnaez1PDW2M3yujCPwDdQBIR8tPXrTAlC/A==",
+			"version": "6.17.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.17.0.tgz",
+			"integrity": "sha512-6o4Tp9rrGaa2ExnkCjvBZl9CVETFptb6NWtpikrkhGC2HtCSFhXWMzYheK0t+4xSJcssrpm6BMSAQGGGFm6+Tg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -9407,9 +9180,9 @@
 			}
 		},
 		"node_modules/@wordpress/browserslist-config": {
-			"version": "6.39.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.39.0.tgz",
-			"integrity": "sha512-fHVG274KKjgAyF7ruvKe+H2JXKh3T7wh3jMrLYoIUx39Hr/LfjYbnsVqWaUDyRhx4nLnk0XIpBfGc+38TDuROQ==",
+			"version": "6.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.40.0.tgz",
+			"integrity": "sha512-aX44MD4Kcr4LZT1YWa3VkMUUJjNfAgt7UECs/qrNGM8tC3l4/2Z4zRkJfpK3AoaXusb1J8+r5ZXWJWhxYK1JMQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -9418,9 +9191,9 @@
 			}
 		},
 		"node_modules/@wordpress/dependency-extraction-webpack-plugin": {
-			"version": "6.40.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.40.0.tgz",
-			"integrity": "sha512-C6QZUieZoOEeZqT265EGIn95vIA1Nt6BPCOi1JyuJQ2hxOgk/cz4Vj7a31zJzCu/c1BKN3R6n78lB6nAuyZrVQ==",
+			"version": "6.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.41.0.tgz",
+			"integrity": "sha512-OYg+g+MFmHRRUcjl5hNOrBx56GRkp6MNhHuiAvYP7vFJ8dxwzKmk3AHfqr25QLt3K62ODHK1aaikE1dZt40kNg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -9442,9 +9215,9 @@
 			"license": "BSD"
 		},
 		"node_modules/@wordpress/e2e-test-utils-playwright": {
-			"version": "1.40.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.40.0.tgz",
-			"integrity": "sha512-7EMx/5R0l9mlR4s01I06x8bw7qq30VlU98T/tvYJa+ycFQK3oetkoPyiNfki2Y2SILQGjI3Mu4MSV1NPCa/mEw==",
+			"version": "1.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.41.0.tgz",
+			"integrity": "sha512-WgWvCMssst//kF1s7sBq92FKMAyQ6epbocNaF8R1i5opCMhEstXlqM9F78Ud15D/8buvbDAmHpumpBufMh93cg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -9464,15 +9237,15 @@
 			}
 		},
 		"node_modules/@wordpress/element": {
-			"version": "6.40.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.40.0.tgz",
-			"integrity": "sha512-OhU8B2xEGg7c41rh/VRiJLOz6TnM/r5r8sraAg5ISc2bF7s2oAFqLwvlR0/U6ervyYwbK644osWZGQxFyL3huA==",
+			"version": "6.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.41.0.tgz",
+			"integrity": "sha512-1rM2MhP2epOfsqOz2spOaGmCU/ZtwHdLEF5GkCNEih+Mt2v+oM1xWbSNvt8RoP7Fz7DepBfaDpl6rkVYZgAwkQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/react": "^18.3.27",
 				"@types/react-dom": "^18.3.1",
-				"@wordpress/escape-html": "^3.40.0",
+				"@wordpress/escape-html": "^3.41.0",
 				"change-case": "^4.1.2",
 				"is-plain-object": "^5.0.0",
 				"react": "^18.3.0",
@@ -9514,9 +9287,9 @@
 			}
 		},
 		"node_modules/@wordpress/escape-html": {
-			"version": "3.40.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.40.0.tgz",
-			"integrity": "sha512-DD6xWVbnw4fGGgO6DFDTJiLj52om0OG4cYHLz7ZhuipmOlEUGljPYOcrj8uxtlh5EFrqHCIPkOya+qQXUHUSBw==",
+			"version": "3.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.41.0.tgz",
+			"integrity": "sha512-xkif63w2OwcOZiJ+YKOmbuUnXAH0PM7YExA6UdQwxDGunED8L/4BY9f0nTEnDN9wFiUCYnqF4MIvMnWEnPwzUA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -9525,18 +9298,18 @@
 			}
 		},
 		"node_modules/@wordpress/eslint-plugin": {
-			"version": "24.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-24.1.0.tgz",
-			"integrity": "sha512-pYFV1XA2uWgryzdTB/IPF8vVO5MsduKIKBEpQFzPhvazZH5Gvc7orVpO5ZGIvkxKbFLNGmYdAUy2Cj0ng+tSdQ==",
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-24.2.0.tgz",
+			"integrity": "sha512-FBVWV+wZ1vN6fpSZVI8gMOJ8M1q69Lp1jMUzbH46lE+ICKnQDUeX6FkN/dZiG6rOSbHau+qEGbuPwTDe2D3quQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/eslint-parser": "7.25.7",
 				"@typescript-eslint/eslint-plugin": "^6.4.1",
 				"@typescript-eslint/parser": "^6.4.1",
-				"@wordpress/babel-preset-default": "^8.39.0",
-				"@wordpress/prettier-config": "^4.39.0",
-				"@wordpress/theme": "^0.6.0",
+				"@wordpress/babel-preset-default": "^8.40.0",
+				"@wordpress/prettier-config": "^4.40.0",
+				"@wordpress/theme": "^0.7.0",
 				"cosmiconfig": "^7.0.0",
 				"eslint-config-prettier": "^8.3.0",
 				"eslint-import-resolver-typescript": "^4.4.4",
@@ -9778,16 +9551,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/@wordpress/eslint-plugin/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
-		},
 		"node_modules/@wordpress/eslint-plugin/node_modules/eslint-plugin-jest": {
 			"version": "27.9.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.9.0.tgz",
@@ -9966,22 +9729,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/@wordpress/eslint-plugin/node_modules/minimatch": {
-			"version": "9.0.3",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-			"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
 		"node_modules/@wordpress/eslint-plugin/node_modules/semver": {
 			"version": "7.7.4",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -10009,9 +9756,9 @@
 			}
 		},
 		"node_modules/@wordpress/interactivity": {
-			"version": "6.39.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/interactivity/-/interactivity-6.39.0.tgz",
-			"integrity": "sha512-9fjoPCOMdcwX1cGW2P4YBIK8LYkz9lhWHI8kgg4OCmBgkVuaFr+g43jjLojbD5bq2KPJYiQ1bD+hGJcgg4zPeQ==",
+			"version": "6.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/interactivity/-/interactivity-6.40.0.tgz",
+			"integrity": "sha512-VYHZMKzg3w7pRG58aD+M1ZxyicDK9or6WJ3pcVXyp7WaGJrleJqd/jIFj4csIqLGW4kKozNq1NBaqjqVHOnIqA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@preact/signals": "^1.3.0",
@@ -10023,9 +9770,9 @@
 			}
 		},
 		"node_modules/@wordpress/jest-console": {
-			"version": "8.40.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.40.0.tgz",
-			"integrity": "sha512-H7j9Afosm0TvppBjQmXxErUBdWIT0u1mX+toH1liafp0gpxzowYMbv1MAASgAEzPrbL/U0P68GIW3PQXQFO4xg==",
+			"version": "8.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.41.0.tgz",
+			"integrity": "sha512-onUDiCgX11jdgI/Bzy7gqBUBpoeA2zvvLwuTBd943bfJbw+f2rJkBgEeBlxwngqr42tcro/1Sdjx+0LiJuh3BA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -10041,13 +9788,13 @@
 			}
 		},
 		"node_modules/@wordpress/jest-preset-default": {
-			"version": "12.39.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.39.0.tgz",
-			"integrity": "sha512-rFaz2wY88acg6TFiE4/goo0UBiLMgk0u+WaKd/nYO1Nk7sei0qromabEQO2LPJyAs0SZqbz3fFhcibueFMWFwA==",
+			"version": "12.40.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.40.0.tgz",
+			"integrity": "sha512-JkH6Hsesy6cyH+encol7jvQyMtFQYLZyb/VpUrZAfUfymOh7VtSqLSGVyxvw64OLcWKE+cE/xkApvvGFBHzG4w==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/jest-console": "^8.39.0",
+				"@wordpress/jest-console": "^8.40.0",
 				"babel-jest": "29.7.0"
 			},
 			"engines": {
@@ -10060,9 +9807,9 @@
 			}
 		},
 		"node_modules/@wordpress/npm-package-json-lint-config": {
-			"version": "5.40.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.40.0.tgz",
-			"integrity": "sha512-fxIya56Bf+LTnDR07RfAM5VfITl7uQm9kJkY4nUYNRC6xPj5cCLLsIh0x5UWXmYQxTTaSreMKYxDPe4UN7tATA==",
+			"version": "5.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.41.0.tgz",
+			"integrity": "sha512-TtPvEh9TFSMlSWscYxnfXpqYc3TiKQKPc48tIgc8IrK8g6UwdKRkEdL6EMBMdeP8XjQ44nwFzpE0v5NwqHNSOg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -10074,13 +9821,13 @@
 			}
 		},
 		"node_modules/@wordpress/postcss-plugins-preset": {
-			"version": "5.40.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.40.0.tgz",
-			"integrity": "sha512-t8zryWpd6sLUVWbFLkRW9637Nmvx4Odnyu9jQCV5yfLXRubD37x/PVRVx7tUw9SpbbrPzKB4DqpNOF+dTHaICg==",
+			"version": "5.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.41.0.tgz",
+			"integrity": "sha512-3zWCfuySY6WfLLL3fmO8iJ+g3QNceb7NQXFGvSnPRYhR+tJdWLEC7spo+juho3WX7raYkqsxUjYekUmMcJTF9Q==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/base-styles": "^6.16.0",
+				"@wordpress/base-styles": "^6.17.0",
 				"autoprefixer": "^10.4.20",
 				"postcss-import": "^16.1.1"
 			},
@@ -10093,9 +9840,9 @@
 			}
 		},
 		"node_modules/@wordpress/prettier-config": {
-			"version": "4.40.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.40.0.tgz",
-			"integrity": "sha512-6JqPLZtoO1OnZJMVrWy+wwoCrJKD1VZnfNMLvNhhRoY7VypBXk189iyWj26JbOhBfFqIcVQNLNMTt9uTZDNujA==",
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.41.0.tgz",
+			"integrity": "sha512-Zzy+ZvxV6JoUptL2J88w7CNjJbdG/ouILJYWSIm3PWoQQnLgNtGLXqquS2YVfOnOhqdIlcXvMrAFZ0ASQ70B4w==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -10107,9 +9854,9 @@
 			}
 		},
 		"node_modules/@wordpress/private-apis": {
-			"version": "1.40.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.40.0.tgz",
-			"integrity": "sha512-68cwZKVq8Xy8GBzKoDRuV4b3pQ4nJFItY689HXp+poc0XXrnAeC4ZhjeSgS1qGRpFo6RVvLjjcaZsN2OrSSMvQ==",
+			"version": "1.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.41.0.tgz",
+			"integrity": "sha512-5bVOGCJGJyD+5IhGtdLxLBsbJd+B1Ohx93COLbqMY4pGAnhNifNgt1rgsYWUjqHVLh80EnvL4HQeMzEncydNLA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -10118,25 +9865,25 @@
 			}
 		},
 		"node_modules/@wordpress/scripts": {
-			"version": "31.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-31.4.0.tgz",
-			"integrity": "sha512-yy69Ef1YvUdBu980WWPgtuRlqCvQVw28BzqWdXcrxVKTBb11H+nX1ovJPLukmPFM6QXc4ku9y89MWAa1ywMA4w==",
+			"version": "31.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-31.5.0.tgz",
+			"integrity": "sha512-7OS5bpHtnuagG8k9q9BdilHjhQ0MLhY0ypDgnRom5WlgPBshM/SUaF9bQLDnSDeasiD/bIgaDmoxWkfVZ4qSPQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/core": "7.25.7",
 				"@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
 				"@svgr/webpack": "^8.0.1",
-				"@wordpress/babel-preset-default": "^8.39.0",
-				"@wordpress/browserslist-config": "^6.39.0",
-				"@wordpress/dependency-extraction-webpack-plugin": "^6.39.0",
-				"@wordpress/e2e-test-utils-playwright": "^1.39.0",
-				"@wordpress/eslint-plugin": "^24.1.0",
-				"@wordpress/jest-preset-default": "^12.39.0",
-				"@wordpress/npm-package-json-lint-config": "^5.39.0",
-				"@wordpress/postcss-plugins-preset": "^5.39.0",
-				"@wordpress/prettier-config": "^4.39.0",
-				"@wordpress/stylelint-config": "^23.31.0",
+				"@wordpress/babel-preset-default": "^8.40.0",
+				"@wordpress/browserslist-config": "^6.40.0",
+				"@wordpress/dependency-extraction-webpack-plugin": "^6.40.0",
+				"@wordpress/e2e-test-utils-playwright": "^1.40.0",
+				"@wordpress/eslint-plugin": "^24.2.0",
+				"@wordpress/jest-preset-default": "^12.40.0",
+				"@wordpress/npm-package-json-lint-config": "^5.40.0",
+				"@wordpress/postcss-plugins-preset": "^5.40.0",
+				"@wordpress/prettier-config": "^4.40.0",
+				"@wordpress/stylelint-config": "^23.32.0",
 				"adm-zip": "^0.5.9",
 				"babel-jest": "29.7.0",
 				"babel-loader": "9.2.1",
@@ -10192,7 +9939,7 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"@playwright/test": "^1.57.0",
+				"@playwright/test": "^1.58.2",
 				"@wordpress/env": "^10.0.0",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
@@ -11407,14 +11154,14 @@
 			}
 		},
 		"node_modules/@wordpress/stylelint-config": {
-			"version": "23.32.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.32.0.tgz",
-			"integrity": "sha512-CvkKISBezOyzq6yc3+9ZnX0ar2qv3LGB1T8EcawCcwpESyVdfGu8vP7VZMKI8jDmsl2fUXXzt5nDScpXctY17Q==",
+			"version": "23.33.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.33.0.tgz",
+			"integrity": "sha512-DSz76UQakmNvhv9OuI8/Ym8dhqUMYcJ4LP4Hy29pNobrcmaLMu1bwxGFGLVDfv9yyLxic001TBn9leZXPbqliA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@stylistic/stylelint-plugin": "^3.0.1",
-				"@wordpress/theme": "^0.7.0",
+				"@wordpress/theme": "^0.8.0",
 				"stylelint-config-recommended": "^14.0.1",
 				"stylelint-config-recommended-scss": "^14.1.0"
 			},
@@ -11428,6 +11175,33 @@
 			}
 		},
 		"node_modules/@wordpress/stylelint-config/node_modules/@wordpress/theme": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.8.0.tgz",
+			"integrity": "sha512-xXGjWNFHICBuMNfjCjTui5ChkiKmmPTJtsF5tPXnUBXJaw43xxGlL0y7lpCNPJQxz+NPMJ01KlGfxhRsHXjKrQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^6.41.0",
+				"@wordpress/private-apis": "^1.41.0",
+				"colorjs.io": "^0.6.0",
+				"memize": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0",
+				"stylelint": "^16.8.2"
+			},
+			"peerDependenciesMeta": {
+				"stylelint": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/theme": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.7.0.tgz",
 			"integrity": "sha512-ULwLCSKYraIsv83bVH+Hm5pGFen6/0/8xOXQwxMdxeU+8kSm0cTKlpQPNvJGCmAeQb2OgFcowB/8wrUdyqW8UQ==",
@@ -11454,37 +11228,10 @@
 				}
 			}
 		},
-		"node_modules/@wordpress/theme": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.6.0.tgz",
-			"integrity": "sha512-n/O1djUn+jny46JyqCwD77nPV4zCUBIn+0ICp8fDYLXpQ7FfCfCrEfhlkQkcVB45KC1iu6IMAsLOA/9hzavHoQ==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@wordpress/element": "^6.39.0",
-				"@wordpress/private-apis": "^1.39.0",
-				"colorjs.io": "^0.6.0",
-				"memize": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0",
-				"stylelint": "^16.8.2"
-			},
-			"peerDependenciesMeta": {
-				"stylelint": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@wordpress/warning": {
-			"version": "3.40.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.40.0.tgz",
-			"integrity": "sha512-0l3OFa1Z+UdhWRRHX9JWWKofo7Lbi2MqOFzzzn0MC26HOyfieQycjLVLNVNXaaodIKUhap6uDQq+JXbbHm881A==",
+			"version": "3.41.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.41.0.tgz",
+			"integrity": "sha512-WhyGL1y6y18cZwOQeCOI9K+kWc8F9KAni9YQKZVYSriazbSPNOQGWpUdeKZVGbimBEjEspK7FQBE4pUW3q+D8w==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -11493,23 +11240,23 @@
 			}
 		},
 		"node_modules/@wp-playground/blueprints": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@wp-playground/blueprints/-/blueprints-3.1.2.tgz",
-			"integrity": "sha512-46YYZ8FAq0G3aZ/b0d7/jTaBmjpktKz/aiYcZ6KBRQdBwpTg9ujennhlvciEHTwI6mJ4drRfBaEoAjYIIlwsWQ==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@wp-playground/blueprints/-/blueprints-3.1.4.tgz",
+			"integrity": "sha512-prKI8WbKehbQX77nO1y3+XsUgV5mZeQdsndmecWVRKrZXQc3d0RkTCcckkZCYWHYhESF2L4rvzxShwRvSA6jxw==",
 			"dev": true,
 			"dependencies": {
-				"@php-wasm/logger": "3.1.2",
-				"@php-wasm/node": "3.1.2",
-				"@php-wasm/node-polyfills": "3.1.2",
-				"@php-wasm/progress": "3.1.2",
-				"@php-wasm/scopes": "3.1.2",
-				"@php-wasm/stream-compression": "3.1.2",
-				"@php-wasm/universal": "3.1.2",
-				"@php-wasm/util": "3.1.2",
-				"@php-wasm/web-service-worker": "3.1.2",
-				"@wp-playground/common": "3.1.2",
-				"@wp-playground/storage": "3.1.2",
-				"@wp-playground/wordpress": "3.1.2",
+				"@php-wasm/logger": "3.1.4",
+				"@php-wasm/node": "3.1.4",
+				"@php-wasm/node-polyfills": "3.1.4",
+				"@php-wasm/progress": "3.1.4",
+				"@php-wasm/scopes": "3.1.4",
+				"@php-wasm/stream-compression": "3.1.4",
+				"@php-wasm/universal": "3.1.4",
+				"@php-wasm/util": "3.1.4",
+				"@php-wasm/web-service-worker": "3.1.4",
+				"@wp-playground/common": "3.1.4",
+				"@wp-playground/storage": "3.1.4",
+				"@wp-playground/wordpress": "3.1.4",
 				"@zip.js/zip.js": "2.7.57",
 				"ajv": "8.12.0",
 				"async-lock": "1.4.1",
@@ -11517,9 +11264,11 @@
 				"crc-32": "1.2.2",
 				"diff3": "0.0.4",
 				"express": "4.22.0",
+				"fast-xml-parser": "^5.3.4",
 				"fs-ext-extra-prebuilt": "2.2.7",
 				"ignore": "5.3.2",
 				"ini": "4.1.2",
+				"jsonc-parser": "3.3.1",
 				"minimisted": "2.0.1",
 				"octokit": "3.1.2",
 				"pako": "1.0.10",
@@ -11537,24 +11286,24 @@
 			}
 		},
 		"node_modules/@wp-playground/cli": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@wp-playground/cli/-/cli-3.1.2.tgz",
-			"integrity": "sha512-mk9JDUvjwXII+yVZmjYSE1TWdSqdy8MeMm/7S0KpUTgHaVTwaeKH0ImWYDyAeC0H0HSXNbfuEnqe/Rls9cwKEQ==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@wp-playground/cli/-/cli-3.1.4.tgz",
+			"integrity": "sha512-vbJZG32xhtAvNHGrhHCGMiu30wrV7nPYHFmRP0MKNclhrqPtKCUdtDSXBpoyO0aTDs92N4E/JheXJ1qYd5AJVw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/cli-util": "3.1.2",
-				"@php-wasm/logger": "3.1.2",
-				"@php-wasm/node": "3.1.2",
-				"@php-wasm/progress": "3.1.2",
-				"@php-wasm/universal": "3.1.2",
-				"@php-wasm/util": "3.1.2",
-				"@php-wasm/xdebug-bridge": "3.1.2",
-				"@wp-playground/blueprints": "3.1.2",
-				"@wp-playground/common": "3.1.2",
-				"@wp-playground/storage": "3.1.2",
-				"@wp-playground/tools": "3.1.2",
-				"@wp-playground/wordpress": "3.1.2",
+				"@php-wasm/cli-util": "3.1.4",
+				"@php-wasm/logger": "3.1.4",
+				"@php-wasm/node": "3.1.4",
+				"@php-wasm/progress": "3.1.4",
+				"@php-wasm/universal": "3.1.4",
+				"@php-wasm/util": "3.1.4",
+				"@php-wasm/xdebug-bridge": "3.1.4",
+				"@wp-playground/blueprints": "3.1.4",
+				"@wp-playground/common": "3.1.4",
+				"@wp-playground/storage": "3.1.4",
+				"@wp-playground/tools": "3.1.4",
+				"@wp-playground/wordpress": "3.1.4",
 				"@zip.js/zip.js": "2.7.57",
 				"ajv": "8.12.0",
 				"async-lock": "1.4.1",
@@ -11587,14 +11336,14 @@
 			}
 		},
 		"node_modules/@wp-playground/common": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.2.tgz",
-			"integrity": "sha512-HSCzwIe+5EVVsbbEtwdUh4O1805Co1GCOV6WQvshjJRtIzMTbRPtPeigkZVgDOMYvmDYrgBAEw5p9DqNK6mImA==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.4.tgz",
+			"integrity": "sha512-N7R4ZQeGfecAYG/gRSWlcHVdZLGygBN6QAXpemy+xUcks/qPoO1w0VVTJp1uoVJ77b7S0cKZsMcRgh0bYZ7hIQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/universal": "3.1.2",
-				"@php-wasm/util": "3.1.2",
+				"@php-wasm/universal": "3.1.4",
+				"@php-wasm/util": "3.1.4",
 				"ini": "4.1.2"
 			},
 			"engines": {
@@ -11603,23 +11352,20 @@
 			}
 		},
 		"node_modules/@wp-playground/storage": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.1.2.tgz",
-			"integrity": "sha512-TKHtLhgRG73pXm9TRXXYpfZOEbU9/icXccnyy0y45DAPKsAbLQYaLei8JGWGZTONLJr+28t5ZBkmKOQxlQQfyg==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.1.4.tgz",
+			"integrity": "sha512-mstkIeE0Fw+tGw49+n7zoWr4AI3Qe/X3260yJWOvux+Fox+fXwVT1HzUV1z/jayDPnMMEVLaYeHGiUh9ZJiX0w==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/stream-compression": "3.1.2",
-				"@php-wasm/universal": "3.1.2",
-				"@php-wasm/util": "3.1.2",
-				"@php-wasm/web": "3.1.2",
+				"@php-wasm/stream-compression": "3.1.4",
+				"@php-wasm/universal": "3.1.4",
+				"@php-wasm/util": "3.1.4",
 				"@zip.js/zip.js": "2.7.57",
 				"async-lock": "^1.4.1",
 				"clean-git-ref": "^2.0.1",
 				"crc-32": "^1.2.0",
 				"diff3": "0.0.3",
-				"express": "4.22.0",
-				"fs-ext-extra-prebuilt": "2.2.7",
 				"ignore": "^5.1.4",
 				"ini": "4.1.2",
 				"minimisted": "^2.0.0",
@@ -11628,10 +11374,7 @@
 				"pify": "^4.0.1",
 				"readable-stream": "^3.4.0",
 				"sha.js": "^2.4.9",
-				"simple-get": "^4.0.1",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3",
-				"yargs": "17.7.2"
+				"simple-get": "^4.0.1"
 			}
 		},
 		"node_modules/@wp-playground/storage/node_modules/diff3": {
@@ -11652,13 +11395,13 @@
 			}
 		},
 		"node_modules/@wp-playground/tools": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@wp-playground/tools/-/tools-3.1.2.tgz",
-			"integrity": "sha512-Csg/aRY7ZLOHf0Rx71Ka37dTBaec2nknLP9wDQc1mLEAkd+GuXuJQfDz8JHmmbWuPm5K2MAaVJxuQeHk4jOrig==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@wp-playground/tools/-/tools-3.1.4.tgz",
+			"integrity": "sha512-fF6NzZbYdVMlDAJAPQJ910SagRQP4FtGkknvl3Wo/ACcTxFUhxP/zD0wbnp+74EQtvxT6KnqDmYXDtOpHT1Waw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wp-playground/blueprints": "3.1.2",
+				"@wp-playground/blueprints": "3.1.4",
 				"@zip.js/zip.js": "2.7.57",
 				"ajv": "8.12.0",
 				"async-lock": "1.4.1",
@@ -11666,9 +11409,11 @@
 				"crc-32": "1.2.2",
 				"diff3": "0.0.4",
 				"express": "4.22.0",
+				"fast-xml-parser": "^5.3.4",
 				"fs-ext-extra-prebuilt": "2.2.7",
 				"ignore": "5.3.2",
 				"ini": "4.1.2",
+				"jsonc-parser": "3.3.1",
 				"minimisted": "2.0.1",
 				"octokit": "3.1.2",
 				"pako": "1.0.10",
@@ -11686,20 +11431,22 @@
 			}
 		},
 		"node_modules/@wp-playground/wordpress": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@wp-playground/wordpress/-/wordpress-3.1.2.tgz",
-			"integrity": "sha512-8R1gNGrJ2pEliMl67EF8E3aB1ZL+0oZ6FA4ZREjIhaOrqm8ZmBcXnqmrX27cvGM7aJ3FGrQurdq4jIdDd9rp0w==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@wp-playground/wordpress/-/wordpress-3.1.4.tgz",
+			"integrity": "sha512-9xQVLBhE1etvpgxpnj8VISCgplJKkN57RSrRKalNWvfqN7D7mmJE3ZK8m0UTVLfd++tXWOAyIfOjuvjUjzXkNQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/logger": "3.1.2",
-				"@php-wasm/node": "3.1.2",
-				"@php-wasm/universal": "3.1.2",
-				"@php-wasm/util": "3.1.2",
-				"@wp-playground/common": "3.1.2",
+				"@php-wasm/logger": "3.1.4",
+				"@php-wasm/node": "3.1.4",
+				"@php-wasm/universal": "3.1.4",
+				"@php-wasm/util": "3.1.4",
+				"@wp-playground/common": "3.1.4",
 				"express": "4.22.0",
+				"fast-xml-parser": "^5.3.4",
 				"fs-ext-extra-prebuilt": "2.2.7",
 				"ini": "4.1.2",
+				"jsonc-parser": "3.3.1",
 				"wasm-feature-detect": "1.8.0",
 				"ws": "8.18.3",
 				"yargs": "17.7.2"
@@ -12400,9 +12147,9 @@
 			}
 		},
 		"node_modules/axios": {
-			"version": "1.13.5",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-			"integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+			"version": "1.13.6",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+			"integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -12608,7 +12355,6 @@
 			"integrity": "sha512-XvwYM6VZqKoqDll8BmSww5luA5eflDzY0uEFfBJtFKe4PAAtxBjU3YIxzIBzhyaEQBy1VXEQBto4cpN5RZJw+w==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"optional": true,
 			"dependencies": {
 				"bare-events": "^2.5.4",
 				"bare-path": "^3.0.0",
@@ -12629,12 +12375,11 @@
 			}
 		},
 		"node_modules/bare-os": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.7.0.tgz",
-			"integrity": "sha512-64Rcwj8qlnTZU8Ps6JJEdSmxBEUGgI7g8l+lMtsJLl4IsfTcHMTfJ188u2iGV6P6YPRZrtv72B2kjn+hp+Yv3g==",
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.7.1.tgz",
+			"integrity": "sha512-ebvMaS5BgZKmJlvuWh14dg9rbUI84QeV3WlWn6Ph6lFI8jJoh7ADtVTyD2c93euwbe+zgi0DVrl4YmqXeM9aIA==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"optional": true,
 			"engines": {
 				"bare": ">=1.14.0"
 			}
@@ -12645,7 +12390,6 @@
 			"integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"optional": true,
 			"dependencies": {
 				"bare-os": "^3.0.1"
 			}
@@ -12656,7 +12400,6 @@
 			"integrity": "sha512-reUN0M2sHRqCdG4lUK3Fw8w98eeUIZHL5c3H7Mbhk2yVBL+oofgaIp0ieLfD5QXwPCypBpmEEKU2WZKzbAk8GA==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"optional": true,
 			"dependencies": {
 				"streamx": "^2.21.0",
 				"teex": "^1.0.1"
@@ -12680,7 +12423,6 @@
 			"integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"optional": true,
 			"dependencies": {
 				"bare-path": "^3.0.0"
 			}
@@ -13020,16 +12762,16 @@
 			}
 		},
 		"node_modules/cacheable": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.2.tgz",
-			"integrity": "sha512-w+ZuRNmex9c1TR9RcsxbfTKCjSL0rh1WA5SABbrWprIHeNBdmyQLSYonlDy9gpD+63XT8DgZ/wNh1Smvc9WnJA==",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.3.tgz",
+			"integrity": "sha512-iffYMX4zxKp54evOH27fm92hs+DeC1DhXmNVN8Tr94M/iZIV42dqTHSR2Ik4TOSPyOAwKr7Yu3rN9ALoLkbWyQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@cacheable/memory": "^2.0.7",
-				"@cacheable/utils": "^2.3.3",
+				"@cacheable/memory": "^2.0.8",
+				"@cacheable/utils": "^2.4.0",
 				"hookified": "^1.15.0",
-				"keyv": "^5.5.5",
+				"keyv": "^5.6.0",
 				"qified": "^0.6.0"
 			}
 		},
@@ -13208,9 +12950,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001774",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001774.tgz",
-			"integrity": "sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA==",
+			"version": "1.0.30001776",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001776.tgz",
+			"integrity": "sha512-sg01JDPzZ9jGshqKSckOQthXnYwOEP50jeVFhaSFbZcOy05TiuuaffDOfcwtCisJ9kNQuLBFibYywv2Bgm9osw==",
 			"dev": true,
 			"funding": [
 				{
@@ -13470,14 +13212,14 @@
 			}
 		},
 		"node_modules/cli-truncate": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.1.1.tgz",
-			"integrity": "sha512-SroPvNHxUnk+vIW/dOSfNqdy1sPEFkrTk6TUtqLCnBlo3N7TNYYkzzN7uSD6+jVjrdO4+p8nH7JzH6cIvUem6A==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+			"integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"slice-ansi": "^7.1.0",
-				"string-width": "^8.0.0"
+				"slice-ansi": "^8.0.0",
+				"string-width": "^8.2.0"
 			},
 			"engines": {
 				"node": ">=20"
@@ -15833,9 +15575,9 @@
 			}
 		},
 		"node_modules/dedent": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.1.tgz",
-			"integrity": "sha512-9JmrhGZpOlEgOLdQgSm0zxFaYoQon408V1v49aqTWuXENVlnCuY9JBZcXZiCsZQWDjTm5Qf/nIvAy77mXDAjEg==",
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+			"integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
@@ -16292,9 +16034,9 @@
 			"license": "MIT"
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.302",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
-			"integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
+			"version": "1.5.307",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.307.tgz",
+			"integrity": "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -16349,9 +16091,9 @@
 			}
 		},
 		"node_modules/enhanced-resolve": {
-			"version": "5.19.0",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.19.0.tgz",
-			"integrity": "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==",
+			"version": "5.20.0",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.0.tgz",
+			"integrity": "sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -16716,9 +16458,9 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "9.39.2",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
-			"integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
+			"version": "9.39.3",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.3.tgz",
+			"integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -16728,7 +16470,7 @@
 				"@eslint/config-helpers": "^0.4.2",
 				"@eslint/core": "^0.17.0",
 				"@eslint/eslintrc": "^3.3.1",
-				"@eslint/js": "9.39.2",
+				"@eslint/js": "9.39.3",
 				"@eslint/plugin-kit": "^0.4.1",
 				"@humanfs/node": "^0.16.6",
 				"@humanwhocodes/module-importer": "^1.0.1",
@@ -16973,9 +16715,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-jest": {
-			"version": "29.12.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-29.12.1.tgz",
-			"integrity": "sha512-Rxo7r4jSANMBkXLICJKS0gjacgyopfNAsoS0e3R9AHnjoKuQOaaPfmsDJPi8UWwygI099OV/K/JhpYRVkxD4AA==",
+			"version": "29.15.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-29.15.0.tgz",
+			"integrity": "sha512-ZCGr7vTH2WSo2hrK5oM2RULFmMruQ7W3cX7YfwoTiPfzTGTFBMmrVIz45jZHd++cGKj/kWf02li/RhTGcANJSA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -16986,14 +16728,18 @@
 			},
 			"peerDependencies": {
 				"@typescript-eslint/eslint-plugin": "^8.0.0",
-				"eslint": "^8.57.0 || ^9.0.0",
-				"jest": "*"
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+				"jest": "*",
+				"typescript": ">=4.8.4 <6.0.0"
 			},
 			"peerDependenciesMeta": {
 				"@typescript-eslint/eslint-plugin": {
 					"optional": true
 				},
 				"jest": {
+					"optional": true
+				},
+				"typescript": {
 					"optional": true
 				}
 			}
@@ -17858,9 +17604,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-xml-parser": {
-			"version": "5.4.1",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
-			"integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
+			"version": "5.4.2",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.2.tgz",
+			"integrity": "sha512-pw/6pIl4k0CSpElPEJhDppLzaixDEuWui2CUQQBH/ECDf7+y6YwA4Gf7Tyb0Rfe4DIMuZipYj4AEL0nACKglvQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -18125,9 +17871,9 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-			"integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+			"version": "3.3.4",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.4.tgz",
+			"integrity": "sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -18606,32 +18352,6 @@
 			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
 			"dev": true,
 			"license": "BSD-2-Clause"
-		},
-		"node_modules/glob/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
-		},
-		"node_modules/glob/node_modules/minimatch": {
-			"version": "9.0.9",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.2"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
 		},
 		"node_modules/global-modules": {
 			"version": "0.2.3",
@@ -19377,9 +19097,9 @@
 			"license": "MIT"
 		},
 		"node_modules/immutable": {
-			"version": "5.1.4",
-			"resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
-			"integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
+			"version": "5.1.5",
+			"resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
+			"integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -23508,17 +23228,17 @@
 			}
 		},
 		"node_modules/lighthouse/node_modules/puppeteer-core": {
-			"version": "24.37.5",
-			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.37.5.tgz",
-			"integrity": "sha512-ybL7iE78YPN4T6J+sPLO7r0lSByp/0NN6PvfBEql219cOnttoTFzCWKiBOjstXSqi/OKpwae623DWAsL7cn2MQ==",
+			"version": "24.38.0",
+			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.38.0.tgz",
+			"integrity": "sha512-zB3S/tksIhgi2gZRndUe07AudBz5SXOB7hqG0kEa9/YXWrGwlVlYm3tZtwKgfRftBzbmLQl5iwHkQQl04n/mWw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@puppeteer/browsers": "2.13.0",
 				"chromium-bidi": "14.0.0",
 				"debug": "^4.4.3",
-				"devtools-protocol": "0.0.1566079",
-				"typed-query-selector": "^2.12.0",
+				"devtools-protocol": "0.0.1581282",
+				"typed-query-selector": "^2.12.1",
 				"webdriver-bidi-protocol": "0.4.1",
 				"ws": "^8.19.0"
 			},
@@ -23541,9 +23261,9 @@
 			}
 		},
 		"node_modules/lighthouse/node_modules/puppeteer-core/node_modules/devtools-protocol": {
-			"version": "0.0.1566079",
-			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1566079.tgz",
-			"integrity": "sha512-MJfAEA1UfVhSs7fbSQOG4czavUp1ajfg6prlAN0+cmfa2zNjaIbvq8VneP7do1WAQQIvgNJWSMeP6UyI90gIlQ==",
+			"version": "0.0.1581282",
+			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1581282.tgz",
+			"integrity": "sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==",
 			"dev": true,
 			"license": "BSD-3-Clause"
 		},
@@ -24032,6 +23752,23 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/log-update/node_modules/slice-ansi": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+			"integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.2.1",
+				"is-fullwidth-code-point": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
+			}
+		},
 		"node_modules/log-update/node_modules/string-width": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
@@ -24302,19 +24039,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/markdownlint-cli/node_modules/glob/node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/markdownlint-cli/node_modules/ignore": {
 			"version": "5.2.4",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
@@ -24344,19 +24068,6 @@
 			"integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/markdownlint-cli/node_modules/minimatch": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
-			"integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
 		},
 		"node_modules/markdownlint-rule-helpers": {
 			"version": "0.16.0",
@@ -24418,20 +24129,20 @@
 			}
 		},
 		"node_modules/memfs": {
-			"version": "4.56.10",
-			"resolved": "https://registry.npmjs.org/memfs/-/memfs-4.56.10.tgz",
-			"integrity": "sha512-eLvzyrwqLHnLYalJP7YZ3wBe79MXktMdfQbvMrVD80K+NhrIukCVBvgP30zTJYEEDh9hZ/ep9z0KOdD7FSHo7w==",
+			"version": "4.56.11",
+			"resolved": "https://registry.npmjs.org/memfs/-/memfs-4.56.11.tgz",
+			"integrity": "sha512-/GodtwVeKVIHZKLUSr2ZdOxKBC5hHki4JNCU22DoCGPEHr5o2PD5U721zvESKyWwCfTfavFl9WZYgA13OAYK0g==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@jsonjoy.com/fs-core": "4.56.10",
-				"@jsonjoy.com/fs-fsa": "4.56.10",
-				"@jsonjoy.com/fs-node": "4.56.10",
-				"@jsonjoy.com/fs-node-builtins": "4.56.10",
-				"@jsonjoy.com/fs-node-to-fsa": "4.56.10",
-				"@jsonjoy.com/fs-node-utils": "4.56.10",
-				"@jsonjoy.com/fs-print": "4.56.10",
-				"@jsonjoy.com/fs-snapshot": "4.56.10",
+				"@jsonjoy.com/fs-core": "4.56.11",
+				"@jsonjoy.com/fs-fsa": "4.56.11",
+				"@jsonjoy.com/fs-node": "4.56.11",
+				"@jsonjoy.com/fs-node-builtins": "4.56.11",
+				"@jsonjoy.com/fs-node-to-fsa": "4.56.11",
+				"@jsonjoy.com/fs-node-utils": "4.56.11",
+				"@jsonjoy.com/fs-print": "4.56.11",
+				"@jsonjoy.com/fs-snapshot": "4.56.11",
 				"@jsonjoy.com/json-pack": "^1.11.0",
 				"@jsonjoy.com/util": "^1.9.0",
 				"glob-to-regex.js": "^1.0.1",
@@ -24694,9 +24405,9 @@
 			"license": "ISC"
 		},
 		"node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
+			"integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -25005,9 +24716,9 @@
 			"license": "MIT"
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.27",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-			"integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+			"version": "2.0.36",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
+			"integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -26598,9 +26309,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.6",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-			"integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+			"version": "8.5.8",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+			"integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
 			"dev": true,
 			"funding": [
 				{
@@ -27544,9 +27255,9 @@
 			"license": "MIT"
 		},
 		"node_modules/pump": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-			"integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+			"integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -27688,16 +27399,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/randombytes": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"safe-buffer": "^5.1.0"
 			}
 		},
 		"node_modules/range-parser": {
@@ -28602,9 +28303,9 @@
 			}
 		},
 		"node_modules/sax": {
-			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
-			"integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.5.0.tgz",
+			"integrity": "sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"engines": {
@@ -28753,13 +28454,13 @@
 			}
 		},
 		"node_modules/serialize-javascript": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-			"integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.4.tgz",
+			"integrity": "sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==",
 			"dev": true,
 			"license": "BSD-3-Clause",
-			"dependencies": {
-				"randombytes": "^2.1.0"
+			"engines": {
+				"node": ">=20.0.0"
 			}
 		},
 		"node_modules/serve-index": {
@@ -29199,17 +28900,17 @@
 			}
 		},
 		"node_modules/slice-ansi": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
-			"integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+			"integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"ansi-styles": "^6.2.1",
-				"is-fullwidth-code-point": "^5.0.0"
+				"ansi-styles": "^6.2.3",
+				"is-fullwidth-code-point": "^5.1.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
@@ -29932,9 +29633,9 @@
 			}
 		},
 		"node_modules/strnum": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
-			"integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
+			"integrity": "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==",
 			"dev": true,
 			"funding": [
 				{
@@ -30222,9 +29923,9 @@
 			"license": "MIT"
 		},
 		"node_modules/stylelint/node_modules/cosmiconfig": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
-			"integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
+			"integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -30724,13 +30425,14 @@
 			}
 		},
 		"node_modules/tar-stream": {
-			"version": "3.1.7",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
-			"integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+			"version": "3.1.8",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
+			"integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"b4a": "^1.6.4",
+				"bare-fs": "^4.5.5",
 				"fast-fifo": "^1.2.0",
 				"streamx": "^2.15.0"
 			}
@@ -30756,7 +30458,6 @@
 			"integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
 			"dev": true,
 			"license": "MIT",
-			"optional": true,
 			"dependencies": {
 				"streamx": "^2.12.5"
 			}
@@ -30812,16 +30513,15 @@
 			}
 		},
 		"node_modules/terser-webpack-plugin": {
-			"version": "5.3.16",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
-			"integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
+			"version": "5.3.17",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.17.tgz",
+			"integrity": "sha512-YR7PtUp6GMU91BgSJmlaX/rS2lGDbAF7D+Wtq7hRO+MiljNmodYvqslzCFiYVAgW+Qoaaia/QUIP4lGXufjdZw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/trace-mapping": "^0.3.25",
 				"jest-worker": "^27.4.5",
 				"schema-utils": "^4.3.0",
-				"serialize-javascript": "^6.0.2",
 				"terser": "^5.31.1"
 			},
 			"engines": {
@@ -31074,20 +30774,20 @@
 			}
 		},
 		"node_modules/tldts-core": {
-			"version": "7.0.23",
-			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.23.tgz",
-			"integrity": "sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ==",
+			"version": "7.0.24",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.24.tgz",
+			"integrity": "sha512-pj7yygNMoMRqG7ML2SDQ0xNIOfN3IBDUcPVM2Sg6hP96oFNN2nqnzHreT3z9xLq85IWJyNTvD38O002DdOrPMw==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/tldts-icann": {
-			"version": "7.0.23",
-			"resolved": "https://registry.npmjs.org/tldts-icann/-/tldts-icann-7.0.23.tgz",
-			"integrity": "sha512-LMc6V1KOHFjKDU8wyDsIEJdV8o2bpc2OaYw2NxncJB2oZxJMPpiNVAbiu1HnqsUy81fkK1QWwFztVqY81hUFEg==",
+			"version": "7.0.24",
+			"resolved": "https://registry.npmjs.org/tldts-icann/-/tldts-icann-7.0.24.tgz",
+			"integrity": "sha512-WgCMgvvJEUBU0ZByo0dz8mdLDJE0XoVdu6egZDPJYX2aaxHGX8dJEbF4Il5+M6qix8Br9O5OOeLfyyESU0MoEQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"tldts-core": "^7.0.23"
+				"tldts-core": "^7.0.24"
 			}
 		},
 		"node_modules/tldts/node_modules/tldts-core": {
@@ -32010,9 +31710,9 @@
 			}
 		},
 		"node_modules/webpack": {
-			"version": "5.105.3",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.3.tgz",
-			"integrity": "sha512-LLBBA4oLmT7sZdHiYE/PeVuifOxYyE2uL/V+9VQP7YSYdJU7bSf7H8bZRRxW8kEPMkmVjnrXmoR3oejIdX0xbg==",
+			"version": "5.105.4",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.4.tgz",
+			"integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -32026,7 +31726,7 @@
 				"acorn-import-phases": "^1.0.3",
 				"browserslist": "^4.28.1",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.19.0",
+				"enhanced-resolve": "^5.20.0",
 				"es-module-lexer": "^2.0.0",
 				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",
@@ -32038,7 +31738,7 @@
 				"neo-async": "^2.6.2",
 				"schema-utils": "^4.3.3",
 				"tapable": "^2.3.0",
-				"terser-webpack-plugin": "^5.3.16",
+				"terser-webpack-plugin": "^5.3.17",
 				"watchpack": "^2.5.1",
 				"webpack-sources": "^3.3.4"
 			},

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
 		"url": "https://github.com/rtCamp/theme-elementary/issues"
 	},
 	"overrides": {
-		"webpack-dev-server": "^5.2.1"
+		"webpack-dev-server": "^5.2.1",
+		"serialize-javascript": "^7.0.3",
+		"minimatch": "3.1.3"
 	},
 	"dependencies": {
 		"@wordpress/interactivity": "6.40.0"
@@ -28,14 +30,14 @@
 		"@babel/core": "7.29.0",
 		"@wordpress/babel-preset-default": "8.40.0",
 		"@wordpress/browserslist-config": "6.40.0",
-		"@wordpress/env": "11.0.0",
+		"@wordpress/env": "^10.39.0",
 		"@wordpress/eslint-plugin": "24.2.0",
 		"@wordpress/jest-preset-default": "12.40.0",
 		"@wordpress/scripts": "31.5.0",
 		"browserslist": "4.28.1",
 		"cross-env": "10.1.0",
 		"css-minimizer-webpack-plugin": "7.0.4",
-		"eslint": "10.0.2",
+		"eslint": "^9.39.0",
 		"eslint-plugin-eslint-comments": "3.2.0",
 		"eslint-plugin-import": "2.32.0",
 		"eslint-plugin-jest": "29.15.0",


### PR DESCRIPTION
## Description

This PR updates and aligns project dependencies to maintain compatibility with the current development ecosystem and ensure overall build stability.

No functional or UI changes are introduced.

---

## Technical Details

### Updated Runtime Dependency

- `@wordpress/interactivity`: 6.39.0 → 6.40.0

### Updated WordPress Tooling (devDependencies)

- `@wordpress/babel-preset-default`: 8.39.0 → 8.40.0
- `@wordpress/browserslist-config`: 6.39.0 → 6.40.0
- `@wordpress/env`: 10.39.0 → 11.0.0
- `@wordpress/eslint-plugin`: 24.1.0 → 24.2.0
- `@wordpress/jest-preset-default`: 12.39.0 → 12.40.0
- `@wordpress/scripts`: 31.4.0 → 31.5.0

### Updated Tooling / Linting Stack

- `eslint`: 9.39.2 → 10.0.2
- `eslint-plugin-jest`: 29.12.1 → 29.15.0

### Notes

- All `@wordpress/*` packages were upgraded together to maintain version alignment.
- `@wordpress/env` was upgraded to a new major version (11.0.0) and validated locally.
- ESLint major upgrade (v10) was verified against the current `@wordpress/scripts` setup.
- `webpack-dev-server` override (`^5.2.1`) remains unchanged.
- `--experimental-modules` flag remains in use and was validated during build.

### Validation Performed

- Clean install with regenerated lockfile
- `npm run build:dev`
- `npm run build:prod`
- `npm run lint:all`
- `npm run test:js`
- PHP tests via `wp-env`
- Manual verification of editor and frontend rendering
- Console checked for runtime warnings/errors

No regressions observed.

---

## Checklist

- [x] Updated `@wordpress/interactivity`
- [x] Updated all `@wordpress/*` devDependencies in sync
- [x] Upgraded `@wordpress/env` to v11
- [x] Upgraded ESLint to v10
- [x] Validated development build
- [x] Validated production build
- [x] Verified lint passes
- [x] Verified JS tests
- [x] Verified PHP tests
- [x] Confirmed editor and frontend stability
- [x] Regenerated `package-lock.json`

---

## Screenshots

Not applicable — no UI or functional changes.

---

## Fixes/Covers issue

Fixes #609