### PR TITLE
feat: add rtcamp-standard reusable workflow with build-artifact gate and PHPStan

### DIFF
--- a/.github/workflows/rtcamp-standard.yml
+++ b/.github/workflows/rtcamp-standard.yml
@@ -21,48 +21,10 @@ permissions:
 jobs:
   build-artifact-gate:
     name: 'Block committed build artifacts'
-    runs-on: ubuntu-latest
     if: ${{ github.event_name == 'pull_request' }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Fetch base branch
-        run: git fetch --depth=1 --no-tags origin "${{ github.base_ref }}"
-
-      - name: Detect committed build artifacts
-        env:
-          GATED_PATHS: ${{ inputs.build-artifact-paths }}
-        run: |
-          set -euo pipefail
-
-          PATTERN=$(printf '%s\n' "$GATED_PATHS" \
-            | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' \
-            | grep -v '^$' \
-            | sed 's/\./\\./g' \
-            | paste -sd '|' -)
-
-          if [[ -z "$PATTERN" ]]; then
-            echo "No gated paths configured; skipping."
-            exit 0
-          fi
-
-          ANCHORED="^(${PATTERN})"
-          echo "Checking changed files against: ${ANCHORED}"
-
-          CHANGED=$(git diff --name-only --diff-filter=ACMR FETCH_HEAD HEAD \
-            | grep -E "${ANCHORED}" || true)
-
-          if [[ -n "$CHANGED" ]]; then
-            echo "::error::Build artifacts must not be committed. Offending files:"
-            printf '%s\n' "$CHANGED" | sed 's/^/  - /'
-            echo
-            echo "These paths are produced by CI on merge. Remove them from the PR"
-            echo "(e.g. 'git rm --cached <file>') and ensure they are gitignored."
-            exit 1
-          fi
-
-          echo "No committed build artifacts detected."
+    uses: rtCamp/wp-shared-workflows/.github/workflows/ci-build-artifact-gate.yml@ff44a8745c5360e28a5316c39b4468c6cf5e0cb6
+    with:
+      gated-paths: ${{ inputs.build-artifact-paths }}
 
   phpstan:
     name: 'PHPStan'

--- a/.github/workflows/rtcamp-standard.yml
+++ b/.github/workflows/rtcamp-standard.yml
@@ -1,0 +1,97 @@
+name: rtCamp Standard
+
+on:
+  workflow_call:
+    inputs:
+      build-artifact-paths:
+        description: 'Newline-separated paths whose contents must not be committed.'
+        required: false
+        type: string
+        default: |
+          assets/build/
+      run-phpstan:
+        description: 'Whether to run the PHPStan job.'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-artifact-gate:
+    name: 'Block committed build artifacts'
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Fetch base branch
+        run: git fetch --depth=1 --no-tags origin "${{ github.base_ref }}"
+
+      - name: Detect committed build artifacts
+        env:
+          GATED_PATHS: ${{ inputs.build-artifact-paths }}
+        run: |
+          set -euo pipefail
+
+          PATTERN=$(printf '%s\n' "$GATED_PATHS" \
+            | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' \
+            | grep -v '^$' \
+            | sed 's/\./\\./g' \
+            | paste -sd '|' -)
+
+          if [[ -z "$PATTERN" ]]; then
+            echo "No gated paths configured; skipping."
+            exit 0
+          fi
+
+          ANCHORED="^(${PATTERN})"
+          echo "Checking changed files against: ${ANCHORED}"
+
+          CHANGED=$(git diff --name-only --diff-filter=ACMR FETCH_HEAD HEAD \
+            | grep -E "${ANCHORED}" || true)
+
+          if [[ -n "$CHANGED" ]]; then
+            echo "::error::Build artifacts must not be committed. Offending files:"
+            printf '%s\n' "$CHANGED" | sed 's/^/  - /'
+            echo
+            echo "These paths are produced by CI on merge. Remove them from the PR"
+            echo "(e.g. 'git rm --cached <file>') and ensure they are gitignored."
+            exit 1
+          fi
+
+          echo "No committed build artifacts detected."
+
+  phpstan:
+    name: 'PHPStan'
+    runs-on: ubuntu-latest
+    if: ${{ inputs.run-phpstan }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          coverage: none
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Configure Composer cache
+        uses: actions/cache@v5.0.3
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Install Composer dependencies
+        run: composer install --prefer-dist --optimize-autoloader --no-progress --no-interaction --no-scripts
+
+      - name: Run PHPStan
+        run: composer phpstan

--- a/.github/workflows/test-measure.yml
+++ b/.github/workflows/test-measure.yml
@@ -61,7 +61,7 @@ jobs:
           MODIFIED_FILES_DATA=$(node .github/bin/determine-modified-files-count.js "$IGNORE_PATH_REGEX" "$MODIFIED_FILES" "all")
           CSS_FILE_COUNT=$(node .github/bin/determine-modified-files-count.js ".+\.s?css|package\.json|package-lock\.json" "$MODIFIED_FILES")
           JS_FILE_COUNT=$(node .github/bin/determine-modified-files-count.js ".+\.(js|snap)|package\.json|package-lock\.json" "$MODIFIED_FILES")
-          PHP_FILE_COUNT=$(node .github/bin/determine-modified-files-count.js ".+\.php|composer\.(json|lock)|phpstan\.neon\.dist" "$MODIFIED_FILES")
+          PHP_FILE_COUNT=$(node .github/bin/determine-modified-files-count.js ".+\.php|composer\.(json|lock)|phpstan\.neon\.dist|phpstan-baseline\.neon" "$MODIFIED_FILES")
           GHA_WORKFLOW_COUNT=$(node .github/bin/determine-modified-files-count.js "(\.github\/(workflows|actions)\/.+\.yml)" "$MODIFIED_FILES")
 
           echo "Changed file count: $MODIFIED_FILES_DATA"
@@ -218,3 +218,11 @@ jobs:
         run: npm run build:prod
         env:
           CI: true
+
+  rtcamp-standard:
+    name: 'rtCamp Standard'
+    needs: pre-run
+    if: ${{ github.event_name == 'pull_request' }}
+    uses: ./.github/workflows/rtcamp-standard.yml
+    with:
+      run-phpstan: ${{ fromJSON(needs.pre-run.outputs.changed-php-count) > 0 }}


### PR DESCRIPTION
## Description

Adds a reusable CI workflow (`.github/workflows/rtcamp-standard.yml`) that enforces build artifact gating and runs PHPStan static analysis. Also introduces a shared composite action for Node.js setup with `node_modules` caching.

## Technical Details

- **Build artifact gate:** Blocks PRs that commit files under `assets/build/`. Uses `FETCH_HEAD` diff pattern consistent with `pre-run` job. Handles renames/copies (`--diff-filter=ACMR`), strips whitespace from path inputs, and escapes regex metacharacters in paths.
- **PHPStan job:** Runs `composer phpstan` conditionally based on whether PHP-related files changed. Uses `fromJSON()` coercion for boolean input to avoid string-to-boolean edge cases.
- **Node caching:** `.github/actions/setup-node-with-cache` composite action caches `node_modules` keyed on `package-lock.json` + `.npmrc` + Node version. Used by all Node-dependent jobs.
- `rtcamp-standard` is called from `test-measure.yml` as a reusable workflow.

## Checklist

<!--
If the ticket you worked on had any checklist, include that here and mark items that are covered in this PR. Else, create a checklist of all the items this PR covers.

Example:
- [ ] Fix incorrect meta key value for the Contact block.
- [ ] Fix footer button alignment issue.
-->
- [x] `.github/workflows/rtcamp-standard.yml` created as a reusable workflow
- [x] PHPStan job runs and fails on new errors (uses `phpstan-baseline.neon` from [TASK-003](https://github.com/rtCamp/theme-elementary/issues/634))
- [ ] Pa11y checks core template pages against WCAG AA
- [x] Build artifact gate blocks PRs that commit files under `assets/build/`
- [x] `assets/build/` added to `.gitignore`
- [x] All action versions pinned to a specific tag or SHA
- [x] All new jobs pass on a clean branch

## Screenshots

<!-- Add screenshots or screen recordings if applicable and required. -->

## To-do

- Pa11y job to be added in a follow-up once wp-env setup in CI is finalized.
- `phpstan-baseline\.neon` was added to the `pre-run` PHP file detection regex so baseline-only changes trigger PHPStan.
- The `lint-js` job failure is a **pre-existing issue** — ESLint 9 requires `eslint.config.js` (flat config) but the repo still uses `.eslintrc.*`. Unrelated to this PR.

## Fixes/Covers issue

<!-- Add the issue number which the PR is intended to be for. -->
Fixes #642 

<!-- After you're done creating the PR, assign the PR to yourself and assign reviewers for the PR. If unsure about whom to ask for a review, leave blank and ping on the project-specific channel. -->
