### PR TITLE
fix: turn ghostMode off

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -381,6 +381,7 @@ const getBrowserSyncPlugins = () => {
 				notify: false,
 				open: false,
 				logSnippet: false,
+				ghostMode: false,
 			},
 			{
 				injectCss: true,


### PR DESCRIPTION
## Description

This PR turns off browsersync's ghost mode, that mirrors scrolls, clicks and form inputs across all browsers.

## Technical Details

Set `ghostMode: false` in browsersync plugin in webpack config.

## Related to

Issue #672 
