### PR TITLE
feat: add tailwind support for blocks

### DIFF
--- a/inc/Core/Assets.php
+++ b/inc/Core/Assets.php
@@ -62,9 +62,23 @@ class Assets implements Registrable {
 	 * @since 1.0.0
 	 */
 	public function register_hooks(): void {
+		add_action( 'after_setup_theme', [ $this, 'add_editor_styles' ] );
 		add_action( 'wp_enqueue_scripts', [ $this, 'register_assets' ] );
 		add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_assets' ] );
 		add_filter( 'render_block', [ $this, 'enqueue_block_specific_assets' ], 10, 2 );
+	}
+
+	/**
+	 * Register Tailwind stylesheet for the block editor.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @action after_setup_theme
+	 */
+	public function add_editor_styles(): void {
+		if ( $this->tailwind_enabled ) {
+			add_editor_style( $this->assets_dir . '/css/frontend/tailwind.css' );
+		}
 	}
 
 	/**

--- a/tests/php/inc/Core/AssetsTest.php
+++ b/tests/php/inc/Core/AssetsTest.php
@@ -33,6 +33,15 @@ class AssetsTest extends TestCase {
 	}
 
 	/**
+	 * Tear down test.
+	 */
+	public function tear_down(): void {
+		wp_dequeue_style( 'elementary-theme-tailwind' );
+		wp_deregister_style( 'elementary-theme-tailwind' );
+		parent::tear_down();
+	}
+
+	/**
 	 * Test class exists.
 	 */
 	public function test_class_exists(): void {
@@ -52,8 +61,73 @@ class AssetsTest extends TestCase {
 	public function test_register_hooks(): void {
 		$this->instance->register_hooks();
 
+		$this->assertGreaterThan( 0, has_action( 'after_setup_theme', [ $this->instance, 'add_editor_styles' ] ) );
 		$this->assertGreaterThan( 0, has_action( 'wp_enqueue_scripts', [ $this->instance, 'register_assets' ] ) );
 		$this->assertGreaterThan( 0, has_action( 'wp_enqueue_scripts', [ $this->instance, 'enqueue_assets' ] ) );
 		$this->assertGreaterThan( 0, has_filter( 'render_block', [ $this->instance, 'enqueue_block_specific_assets' ] ) );
+	}
+
+	/**
+	 * Test add_editor_styles registers the Tailwind stylesheet when Tailwind is enabled.
+	 */
+	public function test_add_editor_styles_when_tailwind_enabled(): void {
+		global $editor_styles;
+		$before = (array) $editor_styles;
+
+		add_filter( 'elementary_theme_tailwind_enabled', '__return_true' );
+		$instance = new Assets();
+		$instance->add_editor_styles();
+		remove_filter( 'elementary_theme_tailwind_enabled', '__return_true' );
+
+		$added = array_diff( (array) $editor_styles, $before );
+		$found = array_filter( $added, fn( string $s ): bool => str_contains( $s, 'tailwind.css' ) );
+		$this->assertNotEmpty( $found );
+	}
+
+	/**
+	 * Test add_editor_styles does not register the Tailwind stylesheet when Tailwind is disabled.
+	 */
+	public function test_add_editor_styles_when_tailwind_disabled(): void {
+		global $editor_styles;
+		$before = (array) $editor_styles;
+
+		add_filter( 'elementary_theme_tailwind_enabled', '__return_false' );
+		$instance = new Assets();
+		$instance->add_editor_styles();
+		remove_filter( 'elementary_theme_tailwind_enabled', '__return_false' );
+
+		$added = array_diff( (array) $editor_styles, $before );
+		$found = array_filter( $added, fn( string $s ): bool => str_contains( $s, 'tailwind.css' ) );
+		$this->assertEmpty( $found );
+	}
+
+	/**
+	 * Test enqueue_assets enqueues the Tailwind stylesheet on the frontend when enabled.
+	 */
+	public function test_enqueue_assets_enqueues_tailwind_when_enabled(): void {
+		add_filter( 'elementary_theme_tailwind_enabled', '__return_true' );
+		$instance = new Assets();
+
+		wp_register_style( 'elementary-theme-tailwind', 'https://example.com/tailwind.css' );
+		$instance->enqueue_assets();
+
+		remove_filter( 'elementary_theme_tailwind_enabled', '__return_true' );
+
+		$this->assertTrue( wp_style_is( 'elementary-theme-tailwind', 'enqueued' ) );
+	}
+
+	/**
+	 * Test enqueue_assets does not enqueue the Tailwind stylesheet on the frontend when disabled.
+	 */
+	public function test_enqueue_assets_does_not_enqueue_tailwind_when_disabled(): void {
+		add_filter( 'elementary_theme_tailwind_enabled', '__return_false' );
+		$instance = new Assets();
+
+		wp_register_style( 'elementary-theme-tailwind', 'https://example.com/tailwind.css' );
+		$instance->enqueue_assets();
+
+		remove_filter( 'elementary_theme_tailwind_enabled', '__return_false' );
+
+		$this->assertFalse( wp_style_is( 'elementary-theme-tailwind', 'enqueued' ) );
 	}
 }

--- a/tests/php/inc/Core/AssetsTest.php
+++ b/tests/php/inc/Core/AssetsTest.php
@@ -108,7 +108,7 @@ class AssetsTest extends TestCase {
 		add_filter( 'elementary_theme_tailwind_enabled', '__return_true' );
 		$instance = new Assets();
 
-		wp_register_style( 'elementary-theme-tailwind', 'https://example.com/tailwind.css', [], false );
+		wp_register_style( 'elementary-theme-tailwind', 'https://example.com/tailwind.css', [], '1.0.0' );
 		$instance->enqueue_assets();
 
 		remove_filter( 'elementary_theme_tailwind_enabled', '__return_true' );
@@ -123,7 +123,7 @@ class AssetsTest extends TestCase {
 		add_filter( 'elementary_theme_tailwind_enabled', '__return_false' );
 		$instance = new Assets();
 
-		wp_register_style( 'elementary-theme-tailwind', 'https://example.com/tailwind.css', [], false );
+		wp_register_style( 'elementary-theme-tailwind', 'https://example.com/tailwind.css', [], '1.0.0' );
 		$instance->enqueue_assets();
 
 		remove_filter( 'elementary_theme_tailwind_enabled', '__return_false' );

--- a/tests/php/inc/Core/AssetsTest.php
+++ b/tests/php/inc/Core/AssetsTest.php
@@ -108,7 +108,7 @@ class AssetsTest extends TestCase {
 		add_filter( 'elementary_theme_tailwind_enabled', '__return_true' );
 		$instance = new Assets();
 
-		wp_register_style( 'elementary-theme-tailwind', 'https://example.com/tailwind.css' );
+		wp_register_style( 'elementary-theme-tailwind', 'https://example.com/tailwind.css', [], false );
 		$instance->enqueue_assets();
 
 		remove_filter( 'elementary_theme_tailwind_enabled', '__return_true' );
@@ -123,7 +123,7 @@ class AssetsTest extends TestCase {
 		add_filter( 'elementary_theme_tailwind_enabled', '__return_false' );
 		$instance = new Assets();
 
-		wp_register_style( 'elementary-theme-tailwind', 'https://example.com/tailwind.css' );
+		wp_register_style( 'elementary-theme-tailwind', 'https://example.com/tailwind.css', [], false );
 		$instance->enqueue_assets();
 
 		remove_filter( 'elementary_theme_tailwind_enabled', '__return_false' );


### PR DESCRIPTION
## Description

This PR adds tailwind styling supports to the gutenberg editor.

## Technical Details

`add_editor_style()` call is added with the `css/frontend/tailwind.css` path if `tailwind_enabled` is true.
