### PR TITLE
Extend Project Init Script with Feature Toggles

### DIFF
--- a/bin/init.js
+++ b/bin/init.js
@@ -239,6 +239,17 @@ const deriveReplacements = ( f ) => {
 		[ 'elementary_theme', prefix ],
 		[ 'Elementary_Theme', toPascalSnake( prefix ) ],
 		[ 'ELEMENTARY_THEME', prefix.toUpperCase() ],
+		// Bare-"elementary" identifiers (run after the compound tokens above;
+		// specific so the repo URLs and elementary.local examples stay untouched).
+		[ 'Theme Elementary', f.themeName ],
+		[ 'elementary-media-text-interactive', `${ textDomain }-media-text-interactive` ],
+		[ 'elementary/media-text', `${ textDomain }/media-text` ], // Interactivity store namespace
+		[ 'elementary-featured', `${ textDomain }-featured` ],
+		[ 'elementary-browser-sync', `${ textDomain }-browser-sync` ],
+		[ 'elementary-settings', `${ textDomain }-settings` ],
+		[ 'elementary_main_section', `${ prefix }_main_section` ],
+		[ 'elementary_', `${ prefix }_` ], // option-key prefix
+		[ 'Elementary', f.themeName ], // bare label — keep last
 	];
 };
 

--- a/bin/init.js
+++ b/bin/init.js
@@ -3,628 +3,655 @@
 /* eslint no-console: 0 */
 
 /**
+ * Theme setup / feature manager.
+ *
+ * First run (no `.wp-tooling.json`): rename the starter theme to your theme
+ * name, persist the choices, pick optional features (Tailwind, ...), and
+ * optionally set up git/husky. Later runs jump straight to the feature manager,
+ * so features can be toggled any time with `npm run init`.
+ *
+ * The whole flow runs on the wp-tooling TTY UI kit (text / confirm / spinner),
+ * in a single process.
+ */
+
+/**
  * External dependencies
  */
 const fs = require( 'fs' );
 const path = require( 'path' );
-const readline = require( 'readline' );
-const { promisify } = require( 'util' );
 const { execSync } = require( 'child_process' );
+const { text, confirm, spinner, style, CancelledError } = require( '@rtcamp/wp-tooling/ui' );
+
+// Persisted project config. Its presence flips init from "scaffold mode" to
+// "feature-manager mode"; it is also read by webpack and the wp-tooling
+// scaffold engine (namespace / feature flags).
+const CONFIG_FILE = '.wp-tooling.json';
 
 /**
- * Define Constants
+ * @return {string} The theme root directory.
  */
-const rl = readline.createInterface( {
-	input: process.stdin,
-	output: process.stdout,
-} );
+const getRoot = () => path.resolve( __dirname, '../' );
 
-const info = {
-	error: ( message ) => {
-		return `\x1b[31m${ message }\x1b[0m`;
-	},
-	success: ( message ) => {
-		return `\x1b[32m${ message }\x1b[0m`;
-	},
-	warning: ( message ) => {
-		return `\x1b[33m${ message }\x1b[0m`;
-	},
-	message: ( message ) => {
-		return `\x1b[34m${ message }\x1b[0m`;
-	},
+// Set when git is initialized in this session, so cleanup keeps the new .git.
+let isGitInitialized = false;
+
+/**
+ * Entry point.
+ *
+ * @return {Promise<void>}
+ */
+const main = async () => {
+	const args = process.argv.slice( 2 );
+
+	if ( args.includes( '--clean' ) || args.includes( '-c' ) ) {
+		await themeCleanupFlow();
+		return;
+	}
+
+	if ( args.length > 0 ) {
+		console.log( style.error( '\nInvalid arguments.\n' ) );
+		return;
+	}
+
+	if ( fs.existsSync( path.resolve( getRoot(), CONFIG_FILE ) ) ) {
+		// Manage mode: already set up — toggle features only.
+		console.log( style.success( '\nTheme already initialized — opening the feature manager.\n' ) );
+		await runFeatureManager( { install: true } );
+		return;
+	}
+
+	await scaffoldFlow();
 };
 
 /**
- * Return root directory
+ * First-run scaffold flow.
  *
- * @return {string} root directory
+ * @return {Promise<void>}
  */
-const getRoot = () => {
-	return path.resolve( __dirname, '../' );
-}
+const scaffoldFlow = async () => {
+	if ( ! ( await confirm( { message: 'Would you like to set up the theme?', defaultValue: true } ) ) ) {
+		console.log( style.warning( '\nTheme setup cancelled.\n' ) );
+		return;
+	}
 
-let fileContentUpdated = false;
-let fileNameUpdated = false;
-let themeCleanup = false;
-let isGitInitialized = false;
-
-const args = process.argv.slice( 2 );
-
-if ( 0 === args.length ) {
-	rl.question( 'Would you like to setup the theme? (y/n) ', ( answer ) => {
-
-		if ( 'n' === answer.toLowerCase() ) {
-			console.log( info.warning( '\nTheme Setup Cancelled.\n' ) );
-			rl.close();
-		}
-
-		rl.question( 'Enter theme name (shown in WordPress admin)*: ', ( themeName ) => {
-
-			const themeInfo = renderThemeDetails( themeName );
-
-			rl.question( 'Confirm the Theme Details (y/n) ', ( confirm ) => {
-
-				if ( 'n' === confirm.toLowerCase() ) {
-					console.log( info.warning( '\nTheme Setup Cancelled.\n' ) );
-					rl.close();
-				}
-
-				initTheme( themeInfo );
-
-				rl.question( 'Would you like to initialize git (Note: It will delete any `.git` folder already in current directory)? (y/n) ', async ( initialize ) => {
-					if ( 'n' === initialize.toLowerCase() ) {
-						console.log( info.warning( '\nExiting without initializing GitHub.\n' ) );
-						await askQuestionForHuskyInstallation();
-					} else {
-						await initializeGit()
-					}
-					themeCleanupQuestion();
-				} );
-			} );
-		} );
+	const themeName = await text( {
+		message: 'Enter theme name (shown in WordPress admin)',
+		validate: required,
 	} );
-} else if ( ( args.includes( '--clean' ) || args.includes( '-c' ) ) && 1 === args.length ) {
-	themeCleanupQuestion();
-} else {
-	console.log( info.error( '\nInvalid arguments.\n' ) );
-	rl.close();
-}
-rl.on( 'close', () => {
-	process.exit( 0 );
+
+	// Show the derived details; declining opens a per-field editor and loops
+	// until the developer confirms.
+	let fields = defaultFields( themeName.trim() );
+	while ( true ) {
+		renderThemeDetails( fields );
+		if ( await confirm( { message: 'Confirm the theme details?', defaultValue: true } ) ) {
+			break;
+		}
+		console.log( style.info( '\nCustomize each field (press Enter to keep the shown value):' ) );
+		fields = await customizeFields( fields );
+	}
+
+	applyThemeName( fields );
+	applyVersion( fields.version );
+	writeProjectConfig( fields );
+
+	// Pick features (Tailwind, ...). On first run we are usually inside
+	// `npm install` (the prepare hook), so defer the nested npm install.
+	console.log( style.success( '\nChoose optional features for your theme:' ) );
+	await runFeatureManager( { install: false } );
+
+	if ( await confirm( {
+		message: 'Initialize git? (Note: deletes any `.git` folder already in this directory)',
+		defaultValue: false,
+	} ) ) {
+		await initializeGit();
+	} else {
+		console.log( style.warning( '\nSkipping git initialization.' ) );
+		await askHusky();
+	}
+
+	await themeCleanupFlow();
+
+	console.log( style.success(
+		'\nAll set! If you enabled any features, run ' + style.warning( '`npm install`' ) +
+		style.success( ' once to install their dependencies.' ),
+	) );
+	console.log( style.success(
+		'Re-run ' + style.warning( '`npm run init`' ) +
+		style.success( ' any time to toggle features on or off.\n' ),
+	) );
+};
+
+/**
+ * Split a value into lower-cased words on spaces, hyphens, underscores, and
+ * camelCase boundaries. Shared by every case helper below.
+ *
+ * @param {string} value
+ * @return {string[]} Lower-cased words.
+ */
+const words = ( value ) =>
+	String( value )
+		.trim()
+		.replace( /([a-z0-9])([A-Z])/g, '$1 $2' )
+		.split( /[\s\-_]+/ )
+		.filter( Boolean )
+		.map( ( word ) => word.toLowerCase() );
+
+const cap = ( word ) => word.charAt( 0 ).toUpperCase() + word.slice( 1 );
+
+const toKebab = ( value ) => words( value ).join( '-' );
+const toSnake = ( value ) => words( value ).join( '_' );
+const toTrain = ( value ) => words( value ).map( cap ).join( '-' );
+const toCobol = ( value ) => words( value ).join( '-' ).toUpperCase();
+const toPascal = ( value ) => words( value ).map( cap ).join( '' );
+const toPascalSnake = ( value ) => words( value ).map( cap ).join( '_' );
+
+/** A non-empty validator for text() prompts. */
+const required = ( value ) =>
+	value && value.trim() ? undefined : 'This field is required.';
+
+/**
+ * Editable source fields for a theme, defaulted from the theme name. Every
+ * other detail (constants, CSS prefix, case variants) is derived from these.
+ *
+ * @param {string} themeName
+ * @return {Object} Source fields.
+ */
+const defaultFields = ( themeName ) => ( {
+	themeName,
+	version: '1.0.0',
+	textDomain: toKebab( themeName ),
+	namespace: `rtCamp\\Theme\\${ toPascal( themeName ) }`,
+	functionPrefix: toSnake( themeName ),
+	packageName: `rtcamp/${ toKebab( themeName ) }`,
 } );
 
 /**
- * Update composer.json file.
+ * Canonical identity derived from the (possibly edited) source fields. Display,
+ * search-replace, and the saved config all go through this, keeping them in sync.
  *
+ * @param {Object} f Source fields.
+ * @return {Object} Canonical identity values.
+ */
+const resolveIdentity = ( f ) => {
+	const textDomain = toKebab( f.textDomain );
+	const prefix = toSnake( f.functionPrefix );
+	return {
+		themeName: f.themeName,
+		version: f.version,
+		textDomain,
+		namespace: f.namespace.trim(),
+		packageName: f.packageName.trim(),
+		functionPrefix: `${ prefix }_`,
+		cssClassPrefix: `${ textDomain }-`,
+		constantPrefix: prefix.toUpperCase(),
+	};
+};
+
+/**
+ * Prompt for each editable field, defaulting to its current value (Enter keeps
+ * it). Text domain and prefix are normalised to kebab/snake so generated slugs
+ * and identifiers stay valid. No cascade: editing one field never rewrites
+ * another — the table re-renders so the final set is reviewed before confirm.
+ *
+ * @param {Object} f Current source fields.
+ * @return {Promise<Object>} Updated source fields.
+ */
+const customizeFields = async ( f ) => ( {
+	themeName: ( await text( { message: 'Theme name', defaultValue: f.themeName, validate: required } ) ).trim(),
+	version: ( await text( { message: 'Theme version', defaultValue: f.version, validate: required } ) ).trim(),
+	textDomain: toKebab( await text( { message: 'Text domain', defaultValue: f.textDomain, validate: required } ) ),
+	namespace: ( await text( { message: 'PHP namespace', defaultValue: f.namespace, validate: required } ) ).trim(),
+	functionPrefix: toSnake( await text( { message: 'Function / constant prefix', defaultValue: f.functionPrefix, validate: required } ) ),
+	packageName: ( await text( { message: 'Composer package name', defaultValue: f.packageName, validate: required } ) ).trim(),
+} );
+
+/**
+ * Ordered [search, replacement] pairs applied literally across the project.
+ *
+ * Literal `split().join()` (not RegExp) needs no escaping, so the back-slashed
+ * PHP namespace renames safely. Each token family maps to its own field, so the
+ * fields can be customised independently.
+ *
+ * @param {Object} f Source fields.
+ * @return {Array<[string, string]>} Replacement pairs.
+ */
+const deriveReplacements = ( f ) => {
+	const textDomain = toKebab( f.textDomain );
+	const prefix = toSnake( f.functionPrefix );
+	const namespace = f.namespace.trim();
+	return [
+		// PHP namespace uses single back-slashes; composer.json stores them
+		// JSON-escaped (doubled). Cover both so the namespace renames everywhere.
+		[ 'rtCamp\\Theme\\Elementary', namespace ],
+		[ 'rtCamp\\\\Theme\\\\Elementary', namespace.replace( /\\/g, '\\\\' ) ],
+		// Composer package name.
+		[ 'rtcamp/elementary', f.packageName.trim() ],
+		// Human-readable name.
+		[ 'elementary theme', f.themeName.toLowerCase() ],
+		[ 'Elementary Theme', f.themeName ],
+		[ 'ELEMENTARY THEME', f.themeName.toUpperCase() ],
+		// Slug / text domain / CSS prefix.
+		[ 'elementary-theme', textDomain ],
+		[ 'Elementary-Theme', toTrain( textDomain ) ],
+		[ 'ELEMENTARY-THEME', toCobol( textDomain ) ],
+		// snake_case identifiers, function prefix, constants.
+		[ 'elementary_theme', prefix ],
+		[ 'Elementary_Theme', toPascalSnake( prefix ) ],
+		[ 'ELEMENTARY_THEME', prefix.toUpperCase() ],
+	];
+};
+
+/**
+ * Render the theme details table for confirmation. Values come from
+ * {@link resolveIdentity}, so the table shows exactly what will be applied and
+ * saved (and what the scaffold engine later reuses).
+ *
+ * @param {Object} fields Source fields.
  * @return {void}
  */
-const updateComposerJson = () => {
-	console.log( info.message( '\nRemoving post-install-cmd script from the composer.json...' ) );
-	const composerJsonPath = path.resolve( getRoot(), 'composer.json' );
+const renderThemeDetails = ( fields ) => {
+	const id = resolveIdentity( fields );
+	const details = {
+		'Theme Name: ': id.themeName,
+		'Theme Version: ': id.version,
+		'Text Domain: ': id.textDomain,
+		'Package: ': id.packageName,
+		'Namespace: ': id.namespace,
+		'Function Prefix: ': id.functionPrefix,
+		'CSS Class Prefix: ': id.cssClassPrefix,
+		'Version Constant: ': `${ id.constantPrefix }_VERSION`,
+		'Build Dir Constant: ': `${ id.constantPrefix }_BUILD_DIR`,
+		'Build URI Constant: ': `${ id.constantPrefix }_BUILD_URI`,
+	};
+
+	const width = Math.max(
+		...Object.entries( details ).map( ( [ k, v ] ) => k.length + v.length ),
+	);
+
+	console.log( style.success( '\nTheme Details:' ) );
+	console.log( style.warning( '┌' + '─'.repeat( width + 2 ) + '┐' ) );
+	for ( const [ key, value ] of Object.entries( details ) ) {
+		const pad = ' '.repeat( width - ( key.length + value.length ) );
+		console.log(
+			style.warning( '│ ' ) + style.success( key ) + style.info( value ) + pad + style.warning( ' │' ),
+		);
+	}
+	console.log( style.warning( '└' + '─'.repeat( width + 2 ) + '┘' ) );
+};
+
+/**
+ * Apply the theme identity across every project file (contents + filenames),
+ * then regenerate the Composer autoloader for the new namespace.
+ *
+ * @param {Object} fields Source fields.
+ * @return {void}
+ */
+const applyThemeName = ( fields ) => {
+	const replacements = deriveReplacements( fields );
+	const files = getAllFiles( getRoot() );
+
+	const s = spinner( 'Applying your theme name across the project…' );
+	s.start();
+
+	let filesChanged = 0;
+	let filesRenamed = 0;
 
 	try {
-		if ( ! fs.existsSync( composerJsonPath ) ) {
-			return;
+		// 1. Replace file contents.
+		for ( const file of files ) {
+			const original = fs.readFileSync( file, 'utf8' );
+			let updated = original;
+			for ( const [ search, replacement ] of replacements ) {
+				updated = updated.split( search ).join( replacement );
+			}
+			if ( updated !== original ) {
+				fs.writeFileSync( file, updated, 'utf8' );
+				filesChanged++;
+			}
 		}
 
-		const composerJson = JSON.parse( fs.readFileSync( composerJsonPath ) );
+		// 2. Rename files whose name carries a token (e.g. elementary-theme.pot).
+		for ( const file of files ) {
+			const base = path.basename( file );
+			let nextBase = base;
+			for ( const [ search, replacement ] of replacements ) {
+				nextBase = nextBase.split( search ).join( replacement );
+			}
+			if ( nextBase !== base ) {
+				fs.renameSync( file, path.join( path.dirname( file ), nextBase ) );
+				filesRenamed++;
+			}
+		}
 
-		// Remove scripts.
-		delete composerJson.scripts['post-install-cmd'];
-
-		// Commit the changes to file.
-		fs.writeFileSync( composerJsonPath, JSON.stringify( composerJson, null, 2 ) );
-		console.log( info.success( '\ncomposer.json updated successfully!' ), '✨' );
+		s.succeed(
+			`Theme name applied — ${ filesChanged } file(s) updated, ${ filesRenamed } renamed.`,
+		);
 	} catch ( error ) {
-		console.log( info.error( `Error while updating composer.json: ${ error.message }` ) );
-		console.log( info.message( 'Please remove post-install-cmd script from the composer.json file manually.' ) );
+		s.fail( `Failed to apply theme name: ${ error.message }` );
+		throw error;
 	}
-}
+
+	const dump = spinner( 'Regenerating Composer autoloader…' );
+	dump.start();
+	try {
+		execSync( 'composer dump-autoload', { cwd: getRoot(), stdio: 'pipe' } );
+		dump.succeed( 'Composer autoloader regenerated.' );
+	} catch ( error ) {
+		dump.fail( 'Could not run `composer dump-autoload` — run it manually after installing dependencies.' );
+	}
+};
 
 /**
- * Update package.json file.
+ * Apply the chosen version to the style.css header and package.json, surgically
+ * (regex, no reformatting). Version is not a search-replace token, so it is set
+ * here after the rename.
  *
+ * @param {string} version
  * @return {void}
  */
-const updatePackageJson = () => {
-	console.log( info.message( '\nRemoving init script from the package.json...' ) );
-	const packageJsonPath = path.resolve( getRoot(), 'package.json' );
+const applyVersion = ( version ) => {
+	const styleCss = path.resolve( getRoot(), 'style.css' );
+	try {
+		if ( fs.existsSync( styleCss ) ) {
+			const css = fs
+				.readFileSync( styleCss, 'utf8' )
+				.replace( /(^\s*\*?\s*Version:\s*).*$/m, `$1${ version }` );
+			fs.writeFileSync( styleCss, css, 'utf8' );
+		}
+	} catch ( error ) {
+		console.log( style.error( `Error while setting version in style.css: ${ error.message }` ) );
+	}
+
+	const packageJson = path.resolve( getRoot(), 'package.json' );
+	try {
+		if ( fs.existsSync( packageJson ) ) {
+			const json = fs
+				.readFileSync( packageJson, 'utf8' )
+				.replace( /("version"\s*:\s*")[^"]*"/, `$1${ version }"` );
+			fs.writeFileSync( packageJson, json, 'utf8' );
+		}
+	} catch ( error ) {
+		console.log( style.error( `Error while setting version in package.json: ${ error.message }` ) );
+	}
+};
+
+/**
+ * Persist the canonical project identity to `.wp-tooling.json`. This is the
+ * single source of truth future scaffolds reuse via `discover_from: config:<key>`
+ * (namespace is also discoverable from composer.json). The `features` block is
+ * owned by the feature manager.
+ *
+ * @param {Object} fields Source fields.
+ * @return {void}
+ */
+const writeProjectConfig = ( fields ) => {
+	const id = resolveIdentity( fields );
+	const config = {
+		name: id.themeName,
+		version: id.version,
+		textDomain: id.textDomain,
+		namespace: id.namespace,
+		packageName: id.packageName,
+		functionPrefix: id.functionPrefix,
+		cssClassPrefix: id.cssClassPrefix,
+		constantPrefix: id.constantPrefix,
+		features: {},
+	};
 
 	try {
-		if ( ! fs.existsSync( packageJsonPath ) ) {
-			return;
-		}
-
-		const packageJson = JSON.parse( fs.readFileSync( packageJsonPath ) );
-
-		delete packageJson.scripts['init'];
-
-		if ( ! packageJson.scripts['prepare'] ) {
-			return;
-		}
-
-		const prepareScript = packageJson.scripts['prepare'];
-
-		// Check if 'npm run init' is part of the prepare script.
-		if ( ! prepareScript.includes( 'npm run init' ) ) {
-			return;
-		}
-
-		// Split the prepare script into an array of individual scripts.
-		const prepareScriptArray = prepareScript.split( '&&' ).map( ( script ) => script.trim() );
-
-		// Find the index of 'npm run init' in the array.
-		const initScriptIndex = prepareScriptArray.indexOf( 'npm run init' );
-
-		// Remove 'npm run init' from the array if it exists.
-		if ( -1 !== initScriptIndex ) {
-			prepareScriptArray.splice( initScriptIndex, 1 );
-		}
-		// Join the array back into a string and update the 'prepare' script in packageJson.
-		packageJson.scripts['prepare'] = prepareScriptArray.join( ' && ' );
-
-		// Commit the changes to file.
-		fs.writeFileSync( packageJsonPath, JSON.stringify( packageJson, null, 2 ) );
-		console.log( info.success( '\npackage.json updated successfully!' ), '✨' );
+		fs.writeFileSync(
+			path.resolve( getRoot(), CONFIG_FILE ),
+			JSON.stringify( config, null, 2 ) + '\n',
+			'utf8',
+		);
+		console.log( style.success( `Saved project config to ${ CONFIG_FILE }` ), '✨' );
 	} catch ( error ) {
-		console.log( info.error( `Error while updating package.json: ${ error.message }` ) );
-		console.log( info.message( 'Please remove init script and remove npm run init command from the prepare script from the package.json file manually.' ) );
+		console.log( style.error( `Error while writing ${ CONFIG_FILE }: ${ error.message }` ) );
 	}
-}
+};
 
 /**
- * Ask theme claenup question.
+ * Run the wp-tooling feature manager in-process (same TTY UI session as init).
  *
- * @return {void}
+ * @param {Object}  options         Options.
+ * @param {boolean} options.install Whether the feature manager may run npm install.
+ * @return {Promise<void>}
  */
-function themeCleanupQuestion() {
-	rl.question( 'Would you like to run the theme cleanup? (y/n) ', ( cleanup ) => {
-		if ( 'n' === cleanup.toLowerCase() ) {
-			console.log( info.warning( '\nExiting without running theme cleanup.\n' ) );
-		} else {
-			updateComposerJson();
-			updatePackageJson();
-			runThemeCleanup();
+const runFeatureManager = async ( { install = true } = {} ) => {
+	try {
+		const { runFeatures } = require( '@rtcamp/wp-tooling/features' );
+		await runFeatures( { cwd: getRoot(), install } );
+	} catch ( error ) {
+		if ( error && error.name === 'CancelledError' ) {
+			throw error; // handled by main()'s top-level catch
 		}
-		rl.close();
-	} );
-}
+		console.log( style.warning(
+			'\nCould not run the feature manager. Run `npx wp-tooling features` later to manage features.\n',
+		) );
+	}
+};
 
 /**
- * Initialize Git.
+ * Initialize git, set up husky between init and the first commit.
  *
- * @return {void}
+ * @return {Promise<void>}
  */
 const initializeGit = async () => {
-	// Initialize git.
-	console.log( info.success( '\nInitializing git...' ) );
-
-	// Check if .git file exists.
 	const gitDir = path.resolve( getRoot(), '.git' );
 	try {
 		if ( fs.existsSync( gitDir ) ) {
-			// Remove .git directory.
-			fs.rmSync( gitDir, {
-				recursive: true,
-			} );
+			fs.rmSync( gitDir, { recursive: true } );
 		}
 	} catch ( error ) {
-
+		// Ignore — git init below will surface any real problem.
 	}
 
-	const pathToRoot = path.resolve( getRoot() );
-	const gitInitCommand = `git init '${ pathToRoot }'`;
-	const pathToAllFiles = path.resolve( getRoot(), '.' );
-	const gitAddCommand = `git add '${ pathToAllFiles }'`;
-	// Apply --no-verify flag to skip husky pre-commit hook.
-	const gitCommit = `git commit -m 'Initialize project using https://github.com/rtCamp/theme-elementary' --no-verify`;
-
+	const root = path.resolve( getRoot() );
+	const s = spinner( 'Initializing git…' );
+	s.start();
 	try {
-		// Execute git init command in the root directory.
-		execSync( gitInitCommand );
-		console.log( info.success( '\nGit initialized successfully!' ), '✨' );
+		execSync( `git init '${ root }'`, { stdio: 'pipe' } );
 		isGitInitialized = true;
+		s.succeed( 'Git initialized.' );
 
-		await askQuestionForHuskyInstallation();
+		await askHusky();
 
-		// Execute git add command in the root directory.
-		execSync( gitAddCommand );
-
-		// Execute git commit command in the root directory.
-		execSync( gitCommit );
+		execSync( `git add '${ root }'`, { stdio: 'pipe' } );
+		// --no-verify so the husky pre-commit hook does not block the first commit.
+		execSync(
+			"git commit -m 'Initialize project using https://github.com/rtCamp/theme-elementary' --no-verify",
+			{ cwd: root, stdio: 'pipe' },
+		);
 	} catch ( error ) {
-		console.log( info.error( 'Error while installing Git. Please check above for the logs.' ) );
+		s.fail( 'Error while initializing git. Please check the logs above.' );
 	}
 };
 
 /**
- * Ask Question for Husky Installation.
+ * Ask whether to install Husky, then install it.
  *
- * @return {void}
+ * @return {Promise<void>}
  */
-const askQuestionForHuskyInstallation = async () => {
-
-	// Promisify the question function for this instance only as this question is in between another question so code after this was getting executed before this is completed.
-	// There is readlinePromises Interface introduced in v17.0.0 and is in Experimental phase so we are using promisify for now.
-	// In future we can use readlinePromises Interface.
-	const question = promisify( rl.question ).bind( rl );
-	const install = await question( 'Would you like to install Husky? (y/n) ' );
-	if ( 'n' === install.toLowerCase() ) {
-		console.log(info.warning('\nExiting without installing Husky.\n'));
+const askHusky = async () => {
+	if ( ! ( await confirm( { message: 'Would you like to install Husky?', defaultValue: true } ) ) ) {
+		console.log( style.warning( '\nSkipping Husky.\n' ) );
 		return;
 	}
 	installHusky();
-}
+};
 
 /**
- * Install Husky.
+ * Install Husky and wire the pre-commit lint hook.
  *
  * @return {void}
  */
 const installHusky = () => {
-
-	// Search if .git directory exists.
-	const gitDir = path.resolve( getRoot(), '.git' );
-	if ( ! fs.existsSync( gitDir ) ) {
-		console.log( info.warning( '\nGit is not initialized. Please initialize git first.\n' ) );
+	const root = path.resolve( getRoot() );
+	if ( ! fs.existsSync( path.resolve( root, '.git' ) ) ) {
+		console.log( style.warning( '\nGit is not initialized. Please initialize git first.\n' ) );
 		return;
 	}
 
-	// Install Husky.
-	console.log( info.success( '\nInstalling Husky...' ) );
-
-	const pathToRoot = path.resolve( getRoot() );
-	const huskyInstallCommand = `npm install husky@9.0.1 --save-dev --prefix '${ pathToRoot }'`;
-
+	const s = spinner( 'Installing Husky…' );
+	s.start();
 	try {
-		// Execute Husky install command in the root directory.
-		execSync( huskyInstallCommand );
+		execSync( `npm install husky@9.0.1 --save-dev --prefix '${ root }'`, { stdio: 'pipe' } );
 
-		const pathToPackageJson = path.resolve( getRoot(), 'package.json' );
+		// `husky init` overwrites the prepare script; preserve any existing one.
+		const packageJsonPath = path.resolve( root, 'package.json' );
+		let previousPrepare = '';
+		if ( fs.existsSync( packageJsonPath ) ) {
+			const pkg = JSON.parse( fs.readFileSync( packageJsonPath, 'utf8' ) );
+			previousPrepare = ( pkg.scripts && pkg.scripts.prepare ) || '';
+		}
 
-		let prepareScript = '';
+		execSync( 'npx husky init', { cwd: root, stdio: 'pipe' } );
+		fs.writeFileSync( path.resolve( root, '.husky/pre-commit' ), 'npm run lint:staged\n', 'utf8' );
 
-		// Extracting the prepare script from package.json before husky installation ovrwrites it.
-		if ( fs.existsSync( pathToPackageJson ) ) {
-			const packageJson = JSON.parse( fs.readFileSync( pathToPackageJson ) );
-
-			if ( packageJson.scripts && packageJson.scripts.prepare ) {
-				prepareScript = packageJson.scripts.prepare;
+		if ( previousPrepare ) {
+			const pkg = JSON.parse( fs.readFileSync( packageJsonPath, 'utf8' ) );
+			if ( pkg.scripts && pkg.scripts.prepare ) {
+				pkg.scripts.prepare += ` && ${ previousPrepare }`;
+				fs.writeFileSync( packageJsonPath, JSON.stringify( pkg, null, 2 ), 'utf8' );
 			}
 		}
 
-		execSync( 'npx husky init' );
-		execSync( 'echo "npm run lint:staged" > .husky/pre-commit' );
+		s.succeed( 'Husky installed.' );
+	} catch ( error ) {
+		s.fail( 'Error while installing Husky. Please check the logs above.' );
+	}
+};
 
-		if ( '' === prepareScript ) {
+/**
+ * Ask whether to run the theme cleanup, then run it.
+ *
+ * @return {Promise<void>}
+ */
+const themeCleanupFlow = async () => {
+	if ( ! ( await confirm( { message: 'Would you like to run the theme cleanup?', defaultValue: true } ) ) ) {
+		console.log( style.warning( '\nExiting without running theme cleanup.\n' ) );
+		return;
+	}
+	updateComposerJson();
+	updatePackageJson();
+	runThemeCleanup();
+};
+
+/**
+ * Remove the Composer post-install-cmd helper script.
+ *
+ * @return {void}
+ */
+const updateComposerJson = () => {
+	const composerJsonPath = path.resolve( getRoot(), 'composer.json' );
+	try {
+		if ( ! fs.existsSync( composerJsonPath ) ) {
 			return;
 		}
-
-		// Update the prepare script with the old prepare script after husky installation overwrites it.
-		if ( fs.existsSync( pathToPackageJson ) ) {
-			const packageJson = JSON.parse( fs.readFileSync( pathToPackageJson ) );
-
-			if ( packageJson.scripts && packageJson.scripts.prepare ) {
-				packageJson.scripts.prepare += ` && ${ prepareScript }`;
-
-				fs.writeFileSync( pathToPackageJson, JSON.stringify( packageJson, null, 2 ) );
-			}
+		const composerJson = JSON.parse( fs.readFileSync( composerJsonPath, 'utf8' ) );
+		if ( composerJson.scripts ) {
+			delete composerJson.scripts[ 'post-install-cmd' ];
 		}
-
-		console.log( info.success( '\nHusky installed successfully!' ), '✨' );
+		fs.writeFileSync( composerJsonPath, JSON.stringify( composerJson, null, 2 ), 'utf8' );
 	} catch ( error ) {
-		console.log( error );
-		console.log( info.error( 'Error while installing husky. Please check above for the logs.' ) );
+		console.log( style.error( `Error while updating composer.json: ${ error.message }` ) );
 	}
-}
-
-/**
- * Renders the theme setup modal with all necessary information related to the search-replace.
- *
- * @param {string} themeName
- *
- * @return {Object} themeInfo
- */
-const renderThemeDetails = ( themeName ) => {
-	console.log( info.success( '\nFiring up the theme setup...' ) );
-
-	// Ask theme name.
-	if ( ! themeName ) {
-		console.log( info.error( '\nTheme name is required.\n' ) );
-		process.exit( 0 );
-	}
-
-	// Generate theme info.
-	const themeInfo = generateThemeInfo( themeName );
-
-	const themeDetails = {
-		'Theme Name: ': `${ themeInfo.themeName }`,
-		'Theme Version: ': '1.0.0',
-		'Text Domain: ': themeInfo.kebabCase,
-		'Package: ': themeInfo.trainCase,
-		'Namespace: ': themeInfo.pascalSnakeCase,
-		'Function Prefix: ': themeInfo.snakeCaseWithUnderscoreSuffix,
-		'CSS Class Prefix: ': themeInfo.kebabCaseWithHyphenSuffix,
-		'PHP Variable Prefix: ': themeInfo.snakeCaseWithUnderscoreSuffix,
-		'Version Constant: ': `${ themeInfo.macroCase }_VERSION`,
-		'Theme Directory Constant: ': `${ themeInfo.macroCase }_TEMP_DIR`,
-		'Theme Build Directory Constant: ': `${ themeInfo.macroCase }_BUILD_DIR`,
-		'Theme Build Directory URI Constant: ': `${ themeInfo.macroCase }_BUILD_URI`,
-	};
-
-	const biggestStringLength = themeDetails[ 'Theme Build Directory URI Constant: ' ].length + 'Theme Build Directory URI Constant: '.length;
-
-	console.log( info.success( '\nTheme Details:' ) );
-	console.log(
-		info.warning( '┌' + '─'.repeat( biggestStringLength + 2 ) + '┐' ),
-	);
-	Object.keys( themeDetails ).forEach( ( key ) => {
-		console.log(
-			info.warning( '│' + ' ' + info.success( key ) + info.message( themeDetails[ key ] ) + ' ' + ' '.repeat( biggestStringLength - ( themeDetails[ key ].length + key.length ) ) + info.warning( '│' ) ),
-		);
-	} );
-	console.log(
-		info.warning( '└' + '─'.repeat( biggestStringLength + 2 ) + '┘' ),
-	);
-
-	return themeInfo;
 };
 
 /**
- * Initialize new theme
+ * Drop the `prepare` auto-trigger (so `npm install` no longer re-runs init) but
+ * keep the `init` script so the feature manager stays re-runnable.
  *
- * @param {Object} themeInfo
+ * @return {void}
  */
-const initTheme = ( themeInfo ) => {
-	const chunksToReplace = {
-		'rtcamp/elementary': themeInfo.packageName, // Specifically targets composer.json file.
-		'elementary theme': themeInfo.themeNameLowerCase,
-		'Elementary Theme': themeInfo.themeName,
-		'ELEMENTARY THEME': themeInfo.themeNameCobolCase,
-		'elementary-theme': themeInfo.kebabCase,
-		'Elementary-Theme': themeInfo.trainCase,
-		'ELEMENTARY-THEME': themeInfo.cobolCase,
-		elementary_theme: themeInfo.snakeCase,
-		Elementary_Theme: themeInfo.pascalSnakeCase,
-		ELEMENTARY_THEME: themeInfo.macroCase,
-		'elementary-theme-': themeInfo.kebabCaseWithHyphenSuffix,
-		'Elementary-Theme-': themeInfo.trainCaseWithHyphenSuffix,
-		'ELEMENTARY-THEME-': themeInfo.cobolCaseWithHyphenSuffix,
-		elementary_theme_: themeInfo.snakeCaseWithUnderscoreSuffix,
-		Elementary_Theme_: themeInfo.pascalSnakeCaseWithUnderscoreSuffix,
-		ELEMENTARY_THEME_: themeInfo.macroCaseWithUnderscoreSuffix,
-	};
-
-	const files = getAllFiles( getRoot() );
-
-	// File name to replace in.
-	const fileNameToReplace = {};
-	files.forEach( ( file ) => {
-		const fileName = path.basename( file );
-		Object.keys( chunksToReplace ).forEach( ( key ) => {
-			if ( fileName.includes( key ) ) {
-				fileNameToReplace[ fileName ] = fileName.replace( key, chunksToReplace[ key ] );
-			}
-		} );
-	} );
-
-	// Replace files contents.
-	console.log( info.success( '\nUpdating theme details in file(s)...' ) );
-	Object.keys( chunksToReplace ).forEach( ( key ) => {
-		replaceFileContent( files, key, chunksToReplace[ key ] );
-	} );
-
-	if ( ! fileContentUpdated ) {
-		console.log( info.error( 'No file content updated.\n' ) );
-	}
-
-	// Replace file names
-	console.log( info.success( '\nUpdating theme file(s) name...' ) );
-	Object.keys( fileNameToReplace ).forEach( ( key ) => {
-		replaceFileName( files, key, fileNameToReplace[ key ] );
-	} );
-	if ( ! fileNameUpdated ) {
-		console.log( info.error( 'No file name updated.\n' ) );
-	}
-
-	if ( fileContentUpdated || fileNameUpdated ) {
-		console.log( info.success( '\nYour new theme is ready to go!' ), '✨' );
-		// Docs link
-		console.log( info.success( '\nFor more information on how to use this theme, please visit the following link: ' + info.warning( 'https://github.com/rtCamp/theme-elementary/blob/main/README.md\n' ) ) );
-	} else {
-		console.log( info.warning( '\nNo changes were made to your theme.\n' ) );
-	}
-
+const updatePackageJson = () => {
+	const packageJsonPath = path.resolve( getRoot(), 'package.json' );
 	try {
-		const result = execSync( 'composer dump-autoload' );
-		console.log( info.success( result ) );
-	} catch ( error ) {
-		console.log( info.error( `Error while executing composer dump-autoload: ${error}` ) );
-	}
-};
-
-/**
- * Get all files in a directory
- *
- * @param {Array} dir - Directory to search
- */
-const getAllFiles = ( dir ) => {
-	const dirOrFilesIgnore = [
-		'.git',
-		'.github',
-		'node_modules',
-		'vendor',
-	];
-
-	try {
-		let files = fs.readdirSync( dir );
-		files = files.filter( ( fileOrDir ) => ! dirOrFilesIgnore.includes( fileOrDir ) );
-
-		const allFiles = [];
-		files.forEach( ( file ) => {
-			const filePath = path.join( dir, file );
-			const stat = fs.statSync( filePath );
-			if ( stat.isDirectory() ) {
-				allFiles.push( ...getAllFiles( filePath ) );
-			} else {
-				allFiles.push( filePath );
-			}
-		} );
-		return allFiles;
-	} catch ( err ) {
-		console.log( info.error( err ) );
-	}
-};
-
-/**
- * Replace content in file
- *
- * @param {Array}  files           Files to search
- * @param {string} chunksToReplace String to replace
- * @param {string} newChunk        New string to replace with
- */
-const replaceFileContent = ( files, chunksToReplace, newChunk ) => {
-	files.forEach( ( file ) => {
-		const filePath = path.resolve( getRoot(), file );
-
-		try {
-			let content = fs.readFileSync( filePath, 'utf8' );
-			const regex = new RegExp( chunksToReplace, 'g' );
-			content = content.replace( regex, newChunk );
-			if ( content !== fs.readFileSync( filePath, 'utf8' ) ) {
-				fs.writeFileSync( filePath, content, 'utf8' );
-				console.log( info.success( `Updated [${ info.message( chunksToReplace ) }] ${ info.success( 'to' ) } [${ info.message( newChunk ) }] ${ info.success( 'in file' ) } [${ info.message( path.basename( file ) ) }]` ) );
-				fileContentUpdated = true;
-			}
-		} catch ( err ) {
-			console.log( info.error( `\nError: ${ err }` ) );
-		}
-	} );
-};
-
-/**
- * Change File Name
- *
- * @param {Array}  files       Files to search
- * @param {string} oldFileName Old file name
- * @param {string} newFileName New file name
- */
-const replaceFileName = ( files, oldFileName, newFileName ) => {
-	files.forEach( ( file ) => {
-		if ( oldFileName !== path.basename( file ) ) {
+		if ( ! fs.existsSync( packageJsonPath ) ) {
 			return;
 		}
-		const filePath = path.resolve( getRoot(), file );
-		const newFilePath = path.resolve( getRoot(), file.replace( oldFileName, newFileName ) );
-		try {
-			fs.renameSync( filePath, newFilePath );
-			console.log( info.success( `Updated file [${ info.message( path.basename( filePath ) ) }] ${ info.success( 'to' ) } [${ info.message( path.basename( newFilePath ) ) }]` ) );
-			fileNameUpdated = true;
-		} catch ( err ) {
-			console.log( info.error( `\nError: ${ err }` ) );
+		const packageJson = JSON.parse( fs.readFileSync( packageJsonPath, 'utf8' ) );
+		const prepare = packageJson.scripts && packageJson.scripts.prepare;
+		if ( ! prepare || ! prepare.includes( 'npm run init' ) ) {
+			return;
 		}
-	} );
+		const remaining = prepare
+			.split( '&&' )
+			.map( ( script ) => script.trim() )
+			.filter( ( script ) => script !== 'npm run init' );
+
+		if ( remaining.length === 0 ) {
+			delete packageJson.scripts.prepare;
+		} else {
+			packageJson.scripts.prepare = remaining.join( ' && ' );
+		}
+		fs.writeFileSync( packageJsonPath, JSON.stringify( packageJson, null, 2 ), 'utf8' );
+	} catch ( error ) {
+		console.log( style.error( `Error while updating package.json: ${ error.message }` ) );
+	}
 };
 
 /**
- * Generate Theme Info from Theme Name
+ * Delete first-run-only files. Keeps `bin/init.js` and `.wp-tooling.json` so the
+ * feature manager remains re-runnable.
  *
- * @param {string} themeName
- */
-const generateThemeInfo = ( themeName ) => {
-	const themeNameLowerCase = themeName.toLowerCase();
-
-	const kebabCase = themeName.replace( /\s+/g, '-' ).toLowerCase();
-	const packageName = `rtcamp/${ kebabCase }`;
-	const snakeCase = kebabCase.replace( /\-/g, '_' );
-	const kebabCaseWithHyphenSuffix = kebabCase + '-';
-	const snakeCaseWithUnderscoreSuffix = snakeCase + '_';
-
-	const trainCase = kebabCase.replace( /\b\w/g, ( l ) => {
-		return l.toUpperCase();
-	} );
-	const themeNameTrainCase = trainCase.replace( /\-/g, ' ' );
-	const pascalSnakeCase = trainCase.replace( /\-/g, '_' );
-	const trainCaseWithHyphenSuffix = trainCase + '-';
-	const pascalSnakeCaseWithUnderscoreSuffix = pascalSnakeCase + '_';
-
-	const cobolCase = kebabCase.toUpperCase();
-	const themeNameCobolCase = themeNameTrainCase.toUpperCase();
-	const macroCase = snakeCase.toUpperCase();
-	const cobolCaseWithHyphenSuffix = cobolCase + '-';
-	const macroCaseWithUnderscoreSuffix = macroCase + '_';
-
-	return {
-		themeName,
-		packageName,
-		themeNameLowerCase,
-		kebabCase,
-		snakeCase,
-		kebabCaseWithHyphenSuffix,
-		snakeCaseWithUnderscoreSuffix,
-		trainCase,
-		themeNameTrainCase,
-		pascalSnakeCase,
-		trainCaseWithHyphenSuffix,
-		pascalSnakeCaseWithUnderscoreSuffix,
-		cobolCase,
-		themeNameCobolCase,
-		macroCase,
-		cobolCaseWithHyphenSuffix,
-		macroCaseWithUnderscoreSuffix,
-	};
-};
-
-/**
- * Run theme cleanup to delete files and directories
- *
- * It will remove following directories and files:
- * 1. .git
- * 2. .github
- * 3. bin
- * 4. languages
+ * @return {void}
  */
 const runThemeCleanup = () => {
-	const deleteDirs = [
-		'.github',
-		'bin/init.js',
-		'languages',
-	];
-
+	const toRemove = [ '.github', 'languages' ];
 	if ( ! isGitInitialized ) {
-		deleteDirs.push( '.git' );
+		toRemove.push( '.git' );
 	}
 
-	deleteDirs.forEach( ( dir ) => {
-		const dirPath = path.resolve( getRoot(), dir );
+	let removed = 0;
+	for ( const entry of toRemove ) {
+		const target = path.resolve( getRoot(), entry );
 		try {
-			if ( fs.existsSync( dirPath ) ) {
-				let isDirectory = false;
-
-				if ( true === fs.lstatSync( dirPath ).isDirectory() ) {
-					isDirectory = true;
-				}
-
-				// rmSync function introduced in Node v14.14.0. It can delete files and directories recursively.
-				fs.rmSync( dirPath, {
-					recursive: true,
-				} );
-
-				if ( isDirectory ) {
-					console.log( info.success( `Removed directory [${ info.message( dir ) }]` ) );
-				} else {
-					console.log( info.success( `Removed file [${ info.message( dir ) }]` ) );
-				}
-				themeCleanup = true;
+			if ( fs.existsSync( target ) ) {
+				fs.rmSync( target, { recursive: true } );
+				removed++;
 			}
-		} catch ( err ) {
-			console.log( info.error( `\nError: ${ err }` ) );
+		} catch ( error ) {
+			console.log( style.error( `\nError removing ${ entry }: ${ error.message }` ) );
 		}
-	} );
-
-	if ( themeCleanup ) {
-		console.log( info.success( '\nTheme cleanup completed!' ), '✨' );
-	} else {
-		console.log( info.warning( '\nNo theme cleanup required!\n' ) );
 	}
+
+	console.log(
+		removed > 0
+			? style.success( '\nTheme cleanup completed!' ) + ' ✨'
+			: style.warning( '\nNothing to clean up.\n' ),
+	);
 };
+
+/**
+ * Recursively list project files, skipping VCS/build/dependency directories.
+ *
+ * @param {string} dir Directory to scan.
+ * @return {string[]} Absolute file paths.
+ */
+const getAllFiles = ( dir ) => {
+	const ignore = [ '.git', '.github', 'node_modules', 'vendor' ];
+	const out = [];
+	for ( const entry of fs.readdirSync( dir ) ) {
+		if ( ignore.includes( entry ) ) {
+			continue;
+		}
+		const full = path.join( dir, entry );
+		if ( fs.statSync( full ).isDirectory() ) {
+			out.push( ...getAllFiles( full ) );
+		} else {
+			out.push( full );
+		}
+	}
+	return out;
+};
+
+main().catch( ( error ) => {
+	if ( error && error.name === 'CancelledError' ) {
+		console.log( style.warning( '\nSetup cancelled.\n' ) );
+		process.exit( 130 );
+	}
+	console.log( style.error( `\nError: ${ error && error.message ? error.message : error }` ) );
+	process.exit( 1 );
+} );

--- a/bin/init.js
+++ b/bin/init.js
@@ -17,7 +17,7 @@
 const fs = require( 'fs' );
 const path = require( 'path' );
 const { execSync } = require( 'child_process' );
-const { text, confirm, radio, spinner, style } = require( '@rtcamp/wp-tooling/ui' );
+const { text, confirm, checkbox, spinner, style } = require( '@rtcamp/wp-tooling/ui' );
 
 const ROOT = path.resolve( __dirname, '..' );
 
@@ -72,8 +72,8 @@ const scaffoldFlow = async () => {
 		validate: validThemeName,
 	} );
 
-	// Review loop: declining the table opens a field picker — edit one field at
-	// a time, then re-confirm. No cascade: editing one never rewrites another.
+	// Review loop: declining the table opens a multi-select editor, then
+	// re-confirms. No cascade: editing one field never rewrites another.
 	let fields = defaultFields( themeName.trim() );
 	while ( true ) {
 		renderThemeDetails( fields );
@@ -254,32 +254,37 @@ const FIELD_META = [
 ];
 
 /**
- * Field picker: pick one field to edit (defaulting to its current value),
- * looping until "Done". Editing one field never rewrites another.
+ * Field editor: multi-select the fields to change, then edit each chosen one in
+ * turn (defaulting to its current value). The caller re-renders the details
+ * table and re-confirms, so selecting nothing is a safe "never mind". Editing
+ * one field never rewrites another.
  *
  * @param {Object} fields Current source fields.
  * @return {Promise<Object>} Updated source fields.
  */
 const editFields = async ( fields ) => {
 	const f = { ...fields };
-	const done = 'Done — back to summary';
-	while ( true ) {
-		const rows = FIELD_META.map( ( meta ) => ( {
-			meta,
-			text: `${ meta[ 1 ].padEnd( 16 ) }${ f[ meta[ 0 ] ] }`,
-		} ) );
-		const picked = await radio( {
-			message: 'Edit which field?',
-			choices: [ ...rows.map( ( r ) => r.text ), done ],
-		} );
-		if ( picked === done ) {
-			return f;
+	// Map each menu label back to its field meta up front (before any edit
+	// changes a value and with it the label).
+	const byLabel = new Map(
+		FIELD_META.map( ( meta ) => [ `${ meta[ 1 ].padEnd( 16 ) }${ f[ meta[ 0 ] ] }`, meta ] ),
+	);
+	const picked = await checkbox( {
+		message: 'Select the fields to edit',
+		choices: [ ...byLabel.keys() ],
+	} );
+	const chosen = new Set( picked.map( ( label ) => byLabel.get( label )[ 0 ] ) );
+
+	// Edit in canonical order for a predictable prompt sequence.
+	for ( const [ key, , prompt, normalize, validate ] of FIELD_META ) {
+		if ( ! chosen.has( key ) ) {
+			continue;
 		}
-		const [ key, , prompt, normalize, validate ] = rows.find( ( r ) => r.text === picked ).meta;
 		f[ key ] = normalize(
 			await text( { message: prompt, defaultValue: f[ key ], validate } ),
 		);
 	}
+	return f;
 };
 
 /**

--- a/bin/init.js
+++ b/bin/init.js
@@ -5,13 +5,10 @@
 /**
  * Theme setup / feature manager.
  *
- * First run (no `.wp-tooling.json`): rename the starter theme to your theme
- * name, persist the choices, pick optional features (Tailwind, ...), and
- * optionally set up git + git hooks. Later runs jump straight to the feature manager,
- * so features can be toggled any time with `npm run init`.
- *
- * The whole flow runs on the wp-tooling TTY UI kit (text / confirm / spinner),
- * in a single process.
+ * First run (no `.wp-tooling.json`): rename the starter theme, persist the
+ * choices, pick optional features, and optionally set up git + git hooks.
+ * Later runs jump straight to the feature manager, so features can be toggled
+ * any time with `npm run init`.
  */
 
 /**
@@ -20,20 +17,12 @@
 const fs = require( 'fs' );
 const path = require( 'path' );
 const { execSync } = require( 'child_process' );
-const { text, confirm, spinner, style, CancelledError } = require( '@rtcamp/wp-tooling/ui' );
+const { text, confirm, spinner, style } = require( '@rtcamp/wp-tooling/ui' );
 
-// Persisted project config. Its presence flips init from "scaffold mode" to
-// "feature-manager mode"; it is also read by webpack and the wp-tooling
-// scaffold engine (namespace / feature flags).
+const ROOT = path.resolve( __dirname, '..' );
+
+// Presence of the config flips init from scaffold mode to feature-manager mode.
 const CONFIG_FILE = '.wp-tooling.json';
-
-/**
- * @return {string} The theme root directory.
- */
-const getRoot = () => path.resolve( __dirname, '../' );
-
-// Set when git is initialized in this session, so cleanup keeps the new .git.
-let isGitInitialized = false;
 
 /**
  * Entry point.
@@ -44,7 +33,7 @@ const main = async () => {
 	const args = process.argv.slice( 2 );
 
 	if ( args.includes( '--clean' ) || args.includes( '-c' ) ) {
-		await themeCleanupFlow();
+		await themeCleanupFlow( { keepGit: false } );
 		return;
 	}
 
@@ -54,8 +43,7 @@ const main = async () => {
 		return;
 	}
 
-	if ( fs.existsSync( path.resolve( getRoot(), CONFIG_FILE ) ) ) {
-		// Manage mode: already set up — toggle features only.
+	if ( fs.existsSync( path.resolve( ROOT, CONFIG_FILE ) ) ) {
 		console.log( style.success( '\nTheme already initialized — opening the feature manager.\n' ) );
 		await runFeatureManager( { install: true } );
 		return;
@@ -80,8 +68,8 @@ const scaffoldFlow = async () => {
 		validate: required,
 	} );
 
-	// Show the derived details; declining opens a per-field editor and loops
-	// until the developer confirms.
+	// Review loop: declining the table opens a per-field editor. No cascade —
+	// editing one field never silently rewrites another.
 	let fields = defaultFields( themeName.trim() );
 	while ( true ) {
 		renderThemeDetails( fields );
@@ -96,22 +84,22 @@ const scaffoldFlow = async () => {
 	applyVersion( fields.version );
 	writeProjectConfig( fields );
 
-	// Pick features (Tailwind, ...). On first run we are usually inside
-	// `npm install` (the prepare hook), so defer the nested npm install.
 	console.log( style.success( '\nChoose optional features for your theme:' ) );
+	// Init usually runs inside `npm install` (the prepare hook), so the feature
+	// manager records new deps in package.json instead of nesting an install.
 	await runFeatureManager( { install: false } );
 
+	let keepGit = false;
 	if ( await confirm( {
 		message: 'Initialize git? (Note: deletes any `.git` folder already in this directory)',
 		defaultValue: false,
 	} ) ) {
-		await initializeGit();
+		keepGit = await initializeGit();
 	} else {
-		// Git hooks require a repo, so skip the hooks prompt entirely here.
 		console.log( style.warning( '\nSkipping git initialization (and git hooks).' ) );
 	}
 
-	await themeCleanupFlow();
+	await themeCleanupFlow( { keepGit } );
 
 	console.log( style.success(
 		'\nAll set! If you enabled any features, run ' + style.warning( '`npm install`' ) +
@@ -147,13 +135,32 @@ const toCobol = ( value ) => words( value ).join( '-' ).toUpperCase();
 const toPascal = ( value ) => words( value ).map( cap ).join( '' );
 const toPascalSnake = ( value ) => words( value ).map( cap ).join( '_' );
 
-/** A non-empty validator for text() prompts. */
+/**
+ * Non-empty validator for text() prompts.
+ *
+ * @param {string} value
+ * @return {string|undefined} Error message, or undefined when valid.
+ */
 const required = ( value ) =>
 	value && value.trim() ? undefined : 'This field is required.';
 
 /**
- * Editable source fields for a theme, defaulted from the theme name. Every
- * other detail (constants, CSS prefix, case variants) is derived from these.
+ * Collapse doubled backslashes so a namespace pasted from composer.json
+ * (`rtCamp\\Theme\\X`) behaves the same as one typed plainly, and strip
+ * leading/trailing separators that would produce invalid PHP.
+ *
+ * @param {string} value
+ * @return {string} Normalised namespace.
+ */
+const normalizeNamespace = ( value ) =>
+	String( value )
+		.trim()
+		.replace( /\\+/g, '\\' )
+		.replace( /^\\|\\$/g, '' );
+
+/**
+ * Editable source fields, defaulted from the theme name. Everything else
+ * (constants, CSS prefix, case variants) is derived from these.
  *
  * @param {string} themeName
  * @return {Object} Source fields.
@@ -168,8 +175,8 @@ const defaultFields = ( themeName ) => ( {
 } );
 
 /**
- * Canonical identity derived from the (possibly edited) source fields. Display,
- * search-replace, and the saved config all go through this, keeping them in sync.
+ * Canonical identity derived from the (possibly edited) fields. The details
+ * table, the search-replace, and the saved config all go through this.
  *
  * @param {Object} f Source fields.
  * @return {Object} Canonical identity values.
@@ -181,7 +188,7 @@ const resolveIdentity = ( f ) => {
 		themeName: f.themeName,
 		version: f.version,
 		textDomain,
-		namespace: f.namespace.trim(),
+		namespace: normalizeNamespace( f.namespace ),
 		packageName: f.packageName.trim(),
 		functionPrefix: `${ prefix }_`,
 		cssClassPrefix: `${ textDomain }-`,
@@ -190,10 +197,9 @@ const resolveIdentity = ( f ) => {
 };
 
 /**
- * Prompt for each editable field, defaulting to its current value (Enter keeps
- * it). Text domain and prefix are normalised to kebab/snake so generated slugs
- * and identifiers stay valid. No cascade: editing one field never rewrites
- * another — the table re-renders so the final set is reviewed before confirm.
+ * Prompt for each editable field, defaulting to its current value (Enter
+ * keeps it). Text domain and prefix are normalised to kebab/snake so the
+ * generated identifiers stay valid.
  *
  * @param {Object} f Current source fields.
  * @return {Promise<Object>} Updated source fields.
@@ -208,11 +214,10 @@ const customizeFields = async ( f ) => ( {
 } );
 
 /**
- * Ordered [search, replacement] pairs applied literally across the project.
- *
- * Literal `split().join()` (not RegExp) needs no escaping, so the back-slashed
- * PHP namespace renames safely. Each token family maps to its own field, so the
- * fields can be customised independently.
+ * Ordered [search, replacement] pairs applied literally (split/join, so the
+ * back-slashed namespace needs no escaping). Compound tokens come before bare
+ * ones; specific bare-"elementary" identifiers are listed explicitly so repo
+ * URLs and elementary.local examples stay untouched.
  *
  * @param {Object} f Source fields.
  * @return {Array<[string, string]>} Replacement pairs.
@@ -220,88 +225,82 @@ const customizeFields = async ( f ) => ( {
 const deriveReplacements = ( f ) => {
 	const textDomain = toKebab( f.textDomain );
 	const prefix = toSnake( f.functionPrefix );
-	const namespace = f.namespace.trim();
+	const namespace = normalizeNamespace( f.namespace );
 	return [
-		// PHP namespace uses single back-slashes; composer.json stores them
-		// JSON-escaped (doubled). Cover both so the namespace renames everywhere.
+		// composer.json stores the namespace JSON-escaped — cover both forms.
 		[ 'rtCamp\\Theme\\Elementary', namespace ],
 		[ 'rtCamp\\\\Theme\\\\Elementary', namespace.replace( /\\/g, '\\\\' ) ],
-		// Composer package name.
 		[ 'rtcamp/elementary', f.packageName.trim() ],
-		// Human-readable name.
 		[ 'elementary theme', f.themeName.toLowerCase() ],
 		[ 'Elementary Theme', f.themeName ],
 		[ 'ELEMENTARY THEME', f.themeName.toUpperCase() ],
-		// Slug / text domain / CSS prefix.
 		[ 'elementary-theme', textDomain ],
 		[ 'Elementary-Theme', toTrain( textDomain ) ],
 		[ 'ELEMENTARY-THEME', toCobol( textDomain ) ],
-		// snake_case identifiers, function prefix, constants.
 		[ 'elementary_theme', prefix ],
 		[ 'Elementary_Theme', toPascalSnake( prefix ) ],
 		[ 'ELEMENTARY_THEME', prefix.toUpperCase() ],
-		// Bare-"elementary" identifiers (run after the compound tokens above;
-		// specific so the repo URLs and elementary.local examples stay untouched).
 		[ 'Theme Elementary', f.themeName ],
 		[ 'elementary-media-text-interactive', `${ textDomain }-media-text-interactive` ],
-		[ 'elementary/media-text', `${ textDomain }/media-text` ], // Interactivity store namespace
+		[ 'elementary/media-text', `${ textDomain }/media-text` ],
 		[ 'elementary-featured', `${ textDomain }-featured` ],
 		[ 'elementary-browser-sync', `${ textDomain }-browser-sync` ],
 		[ 'elementary-settings', `${ textDomain }-settings` ],
 		[ 'elementary_main_section', `${ prefix }_main_section` ],
-		[ 'elementary_', `${ prefix }_` ], // option-key prefix
+		[ 'elementary_', `${ prefix }_` ],
+		[ 'themes/elementary', `themes/${ textDomain }` ],
 		[ 'Elementary', f.themeName ], // bare label — keep last
 	];
 };
 
 /**
  * Render the theme details table for confirmation. Values come from
- * {@link resolveIdentity}, so the table shows exactly what will be applied and
- * saved (and what the scaffold engine later reuses).
+ * {@link resolveIdentity}, so the table shows exactly what will be applied.
  *
  * @param {Object} fields Source fields.
  * @return {void}
  */
 const renderThemeDetails = ( fields ) => {
 	const id = resolveIdentity( fields );
-	const details = {
-		'Theme Name: ': id.themeName,
-		'Theme Version: ': id.version,
-		'Text Domain: ': id.textDomain,
-		'Package: ': id.packageName,
-		'Namespace: ': id.namespace,
-		'Function Prefix: ': id.functionPrefix,
-		'CSS Class Prefix: ': id.cssClassPrefix,
-		'Version Constant: ': `${ id.constantPrefix }_VERSION`,
-		'Build Dir Constant: ': `${ id.constantPrefix }_BUILD_DIR`,
-		'Build URI Constant: ': `${ id.constantPrefix }_BUILD_URI`,
-	};
+	const rows = Object.entries( {
+		'Theme Name': id.themeName,
+		'Theme Version': id.version,
+		'Text Domain': id.textDomain,
+		Package: id.packageName,
+		Namespace: id.namespace,
+		'Function Prefix': id.functionPrefix,
+		'CSS Class Prefix': id.cssClassPrefix,
+		'Version Constant': `${ id.constantPrefix }_VERSION`,
+		'Build Dir Constant': `${ id.constantPrefix }_BUILD_DIR`,
+		'Build URI Constant': `${ id.constantPrefix }_BUILD_URI`,
+	} ).map( ( [ label, value ] ) => [ `${ label }: `, value ] );
 
-	const width = Math.max(
-		...Object.entries( details ).map( ( [ k, v ] ) => k.length + v.length ),
-	);
+	const width = Math.max( ...rows.map( ( [ label, value ] ) => label.length + value.length ) );
 
 	console.log( style.success( '\nTheme Details:' ) );
-	console.log( style.warning( '┌' + '─'.repeat( width + 2 ) + '┐' ) );
-	for ( const [ key, value ] of Object.entries( details ) ) {
-		const pad = ' '.repeat( width - ( key.length + value.length ) );
+	console.log( style.warning( `┌${ '─'.repeat( width + 2 ) }┐` ) );
+	for ( const [ label, value ] of rows ) {
+		const pad = ' '.repeat( width - label.length - value.length );
 		console.log(
-			style.warning( '│ ' ) + style.success( key ) + style.info( value ) + pad + style.warning( ' │' ),
+			style.warning( '│ ' ) + style.success( label ) + style.info( value ) + pad + style.warning( ' │' ),
 		);
 	}
-	console.log( style.warning( '└' + '─'.repeat( width + 2 ) + '┘' ) );
+	console.log( style.warning( `└${ '─'.repeat( width + 2 ) }┘` ) );
 };
 
 /**
- * Apply the theme identity across every project file (contents + filenames),
- * then regenerate the Composer autoloader for the new namespace.
+ * Apply the identity across all project files — contents first, then
+ * filenames carrying a token (e.g. elementary-theme.pot) — and regenerate the
+ * Composer autoloader for the new namespace.
  *
  * @param {Object} fields Source fields.
  * @return {void}
  */
 const applyThemeName = ( fields ) => {
 	const replacements = deriveReplacements( fields );
-	const files = getAllFiles( getRoot() );
+	const replaceAll = ( value ) =>
+		replacements.reduce( ( out, [ search, replacement ] ) => out.split( search ).join( replacement ), value );
+	const files = getAllFiles( ROOT );
 
 	const s = spinner( 'Applying your theme name across the project…' );
 	s.start();
@@ -310,35 +309,25 @@ const applyThemeName = ( fields ) => {
 	let filesRenamed = 0;
 
 	try {
-		// 1. Replace file contents.
 		for ( const file of files ) {
 			const original = fs.readFileSync( file, 'utf8' );
-			let updated = original;
-			for ( const [ search, replacement ] of replacements ) {
-				updated = updated.split( search ).join( replacement );
-			}
+			const updated = replaceAll( original );
 			if ( updated !== original ) {
 				fs.writeFileSync( file, updated, 'utf8' );
 				filesChanged++;
 			}
 		}
 
-		// 2. Rename files whose name carries a token (e.g. elementary-theme.pot).
 		for ( const file of files ) {
 			const base = path.basename( file );
-			let nextBase = base;
-			for ( const [ search, replacement ] of replacements ) {
-				nextBase = nextBase.split( search ).join( replacement );
-			}
+			const nextBase = replaceAll( base );
 			if ( nextBase !== base ) {
 				fs.renameSync( file, path.join( path.dirname( file ), nextBase ) );
 				filesRenamed++;
 			}
 		}
 
-		s.succeed(
-			`Theme name applied — ${ filesChanged } file(s) updated, ${ filesRenamed } renamed.`,
-		);
+		s.succeed( `Theme name applied — ${ filesChanged } file(s) updated, ${ filesRenamed } renamed.` );
 	} catch ( error ) {
 		s.fail( `Failed to apply theme name: ${ error.message }` );
 		throw error;
@@ -347,52 +336,28 @@ const applyThemeName = ( fields ) => {
 	const dump = spinner( 'Regenerating Composer autoloader…' );
 	dump.start();
 	try {
-		execSync( 'composer dump-autoload', { cwd: getRoot(), stdio: 'pipe' } );
+		execSync( 'composer dump-autoload', { cwd: ROOT, stdio: 'pipe' } );
 		dump.succeed( 'Composer autoloader regenerated.' );
-	} catch ( error ) {
+	} catch {
 		dump.fail( 'Could not run `composer dump-autoload` — run it manually after installing dependencies.' );
 	}
 };
 
 /**
- * Apply the chosen version to the style.css header and package.json, surgically
- * (regex, no reformatting). Version is not a search-replace token, so it is set
- * here after the rename.
+ * Apply the chosen version to style.css and package.json with surgical regex
+ * edits — the version is not a search-replace token.
  *
  * @param {string} version
  * @return {void}
  */
 const applyVersion = ( version ) => {
-	const styleCss = path.resolve( getRoot(), 'style.css' );
-	try {
-		if ( fs.existsSync( styleCss ) ) {
-			const css = fs
-				.readFileSync( styleCss, 'utf8' )
-				.replace( /(^\s*\*?\s*Version:\s*).*$/m, `$1${ version }` );
-			fs.writeFileSync( styleCss, css, 'utf8' );
-		}
-	} catch ( error ) {
-		console.log( style.error( `Error while setting version in style.css: ${ error.message }` ) );
-	}
-
-	const packageJson = path.resolve( getRoot(), 'package.json' );
-	try {
-		if ( fs.existsSync( packageJson ) ) {
-			const json = fs
-				.readFileSync( packageJson, 'utf8' )
-				.replace( /("version"\s*:\s*")[^"]*"/, `$1${ version }"` );
-			fs.writeFileSync( packageJson, json, 'utf8' );
-		}
-	} catch ( error ) {
-		console.log( style.error( `Error while setting version in package.json: ${ error.message }` ) );
-	}
+	replaceInFile( 'style.css', /(^\s*\*?\s*Version:\s*).*$/m, `$1${ version }` );
+	replaceInFile( 'package.json', /("version"\s*:\s*")[^"]*"/, `$1${ version }"` );
 };
 
 /**
- * Persist the canonical project identity to `.wp-tooling.json`. This is the
- * single source of truth future scaffolds reuse via `discover_from: config:<key>`
- * (namespace is also discoverable from composer.json). The `features` block is
- * owned by the feature manager.
+ * Persist the identity that scaffolds reuse via `discover_from: "config:<key>"`.
+ * The `features` block is owned by the wp-tooling feature manager.
  *
  * @param {Object} fields Source fields.
  * @return {void}
@@ -408,12 +373,13 @@ const writeProjectConfig = ( fields ) => {
 		functionPrefix: id.functionPrefix,
 		cssClassPrefix: id.cssClassPrefix,
 		constantPrefix: id.constantPrefix,
+		cssDir: 'src/css/frontend',
 		features: {},
 	};
 
 	try {
 		fs.writeFileSync(
-			path.resolve( getRoot(), CONFIG_FILE ),
+			path.resolve( ROOT, CONFIG_FILE ),
 			JSON.stringify( config, null, '\t' ) + '\n',
 			'utf8',
 		);
@@ -424,86 +390,75 @@ const writeProjectConfig = ( fields ) => {
 };
 
 /**
- * Run the wp-tooling feature manager in-process (same TTY UI session as init).
+ * Run the wp-tooling feature manager in-process (same TTY session as init).
+ * When install is skipped (init already runs inside `npm install`), opt in to
+ * recording new deps in package.json so the next `npm install` picks them up.
  *
  * @param {Object}  options         Options.
- * @param {boolean} options.install Whether the feature manager may run npm install.
+ * @param {boolean} options.install Run npm install for newly enabled features.
  * @return {Promise<void>}
  */
 const runFeatureManager = async ( { install = true } = {} ) => {
 	try {
 		const { runFeatures } = require( '@rtcamp/wp-tooling/features' );
-		await runFeatures( { cwd: getRoot(), install } );
+		await runFeatures( { cwd: ROOT, install, record: ! install } );
 	} catch ( error ) {
 		if ( error && error.name === 'CancelledError' ) {
 			throw error; // handled by main()'s top-level catch
 		}
 		console.log( style.warning(
-			'\nCould not run the feature manager. Run `npx wp-tooling features` later to manage features.\n',
+			`\nCould not run the feature manager: ${ error && error.message ? error.message : error }`,
+		) );
+		console.log( style.warning(
+			'Run `npx wp-tooling features` later to manage features.\n',
 		) );
 	}
 };
 
 /**
- * Initialize git, install git hooks between init and the first commit.
+ * Initialize a fresh git repo, install hooks, and create the first commit.
  *
- * @return {Promise<void>}
+ * @return {Promise<boolean>} True when a repo was created (so cleanup keeps it).
  */
 const initializeGit = async () => {
-	const gitDir = path.resolve( getRoot(), '.git' );
 	try {
-		if ( fs.existsSync( gitDir ) ) {
-			fs.rmSync( gitDir, { recursive: true } );
-		}
-	} catch ( error ) {
-		// Ignore — git init below will surface any real problem.
+		fs.rmSync( path.resolve( ROOT, '.git' ), { recursive: true, force: true } );
+	} catch {
+		// git init below will surface any real problem.
 	}
 
-	const root = path.resolve( getRoot() );
+	let initialized = false;
 	const s = spinner( 'Initializing git…' );
 	s.start();
 	try {
-		execSync( `git init '${ root }'`, { stdio: 'pipe' } );
-		isGitInitialized = true;
+		execSync( 'git init', { cwd: ROOT, stdio: 'pipe' } );
+		initialized = true;
 		s.succeed( 'Git initialized.' );
 
-		await askHooks();
+		await installGitHooks();
 
-		execSync( `git add '${ root }'`, { stdio: 'pipe' } );
-		// --no-verify so the commit-msg / pre-commit hooks do not block the first commit.
+		execSync( 'git add -A', { cwd: ROOT, stdio: 'pipe' } );
+		// --no-verify: the freshly installed hooks must not block this commit.
 		execSync(
 			"git commit -m 'Initialize project using https://github.com/rtCamp/theme-elementary' --no-verify",
-			{ cwd: root, stdio: 'pipe' },
+			{ cwd: ROOT, stdio: 'pipe' },
 		);
-	} catch ( error ) {
+	} catch {
 		s.fail( 'Error while initializing git. Please check the logs above.' );
 	}
+	return initialized;
 };
 
 /**
- * Ask whether to install git hooks, then install them.
- *
- * @return {Promise<void>}
- */
-const askHooks = async () => {
-	if ( ! ( await confirm( { message: 'Would you like to install git hooks (pre-commit lint + commit-msg)?', defaultValue: true } ) ) ) {
-		console.log( style.warning( '\nSkipping git hooks.\n' ) );
-		return;
-	}
-	await installGitHooks();
-};
-
-/**
- * Install the wp-tooling git hooks (pre-commit runs `lint:staged`; commit-msg
- * validates Conventional Commits) into `.git/hooks`, and point `prepare` at
- * `wp-tooling install-hooks` so they reinstall after a fresh clone.
+ * Offer and install the wp-tooling git hooks (pre-commit lint + commit-msg),
+ * pointing `prepare` at `wp-tooling install-hooks` so they reinstall after a
+ * fresh clone (`.git/hooks` is never committed).
  *
  * @return {Promise<void>}
  */
 const installGitHooks = async () => {
-	const root = path.resolve( getRoot() );
-	if ( ! fs.existsSync( path.resolve( root, '.git' ) ) ) {
-		console.log( style.warning( '\nGit is not initialized. Please initialize git first.\n' ) );
+	if ( ! ( await confirm( { message: 'Would you like to install git hooks (pre-commit lint + commit-msg)?', defaultValue: true } ) ) ) {
+		console.log( style.warning( '\nSkipping git hooks.\n' ) );
 		return;
 	}
 
@@ -511,8 +466,12 @@ const installGitHooks = async () => {
 	s.start();
 	try {
 		const { installHooks } = require( '@rtcamp/wp-tooling/hooks' );
-		await installHooks( root, { force: true } );
-		setPrepareScript( root );
+		await installHooks( ROOT, { force: true } );
+		// `|| true` keeps non-git installs (CI / tarball) green.
+		updateJsonFile( 'package.json', ( pkg ) => {
+			pkg.scripts = pkg.scripts || {};
+			pkg.scripts.prepare = 'wp-tooling install-hooks || true';
+		} );
 		s.succeed( 'Git hooks installed (pre-commit + commit-msg).' );
 	} catch ( error ) {
 		s.fail( `Could not install git hooks: ${ error.message }` );
@@ -520,109 +479,78 @@ const installGitHooks = async () => {
 };
 
 /**
- * Point the `prepare` lifecycle script at `wp-tooling install-hooks` so hooks
- * reinstall after a fresh clone (`.git/hooks` is never committed). `|| true`
- * keeps `npm install` from failing where there is no git repo (CI / tarball).
+ * Offer and run the theme cleanup: drop the scaffold-only lifecycle scripts
+ * and delete first-run-only files.
  *
- * @param {string} root Theme root.
- * @return {void}
- */
-const setPrepareScript = ( root ) => {
-	const packageJsonPath = path.resolve( root, 'package.json' );
-	try {
-		const pkg = JSON.parse( fs.readFileSync( packageJsonPath, 'utf8' ) );
-		pkg.scripts = pkg.scripts || {};
-		pkg.scripts.prepare = 'wp-tooling install-hooks || true';
-		fs.writeFileSync( packageJsonPath, JSON.stringify( pkg, null, '\t' ) + '\n', 'utf8' );
-	} catch ( error ) {
-		// Non-fatal: hooks are still installed for this clone.
-	}
-};
-
-/**
- * Ask whether to run the theme cleanup, then run it.
- *
+ * @param {Object}  options         Options.
+ * @param {boolean} options.keepGit Keep `.git` (a repo was created this run).
  * @return {Promise<void>}
  */
-const themeCleanupFlow = async () => {
+const themeCleanupFlow = async ( { keepGit = false } = {} ) => {
 	if ( ! ( await confirm( { message: 'Would you like to run the theme cleanup?', defaultValue: true } ) ) ) {
 		console.log( style.warning( '\nExiting without running theme cleanup.\n' ) );
 		return;
 	}
-	updateComposerJson();
-	updatePackageJson();
-	runThemeCleanup();
+
+	updateJsonFile( 'composer.json', ( json ) => {
+		if ( json.scripts ) {
+			delete json.scripts[ 'post-install-cmd' ];
+		}
+	} );
+	updateJsonFile( 'package.json', cleanupPackageJson );
+	removeScaffoldFiles( keepGit );
 };
 
 /**
- * Remove the Composer post-install-cmd helper script.
+ * Drop `npm run init` from the `prepare` script so `npm install` stops
+ * re-running init (the `init` script itself stays so the feature manager
+ * remains re-runnable), and remove repository/bugs/homepage entries still
+ * pointing at the starter repo — they belong to theme-elementary, not the
+ * scaffolded theme.
  *
- * @return {void}
+ * @param {Object} pkg Parsed package.json.
+ * @return {boolean} False to skip writing when nothing changed.
  */
-const updateComposerJson = () => {
-	const composerJsonPath = path.resolve( getRoot(), 'composer.json' );
-	try {
-		if ( ! fs.existsSync( composerJsonPath ) ) {
-			return;
-		}
-		const composerJson = JSON.parse( fs.readFileSync( composerJsonPath, 'utf8' ) );
-		if ( composerJson.scripts ) {
-			delete composerJson.scripts[ 'post-install-cmd' ];
-		}
-		fs.writeFileSync( composerJsonPath, JSON.stringify( composerJson, null, '\t' ) + '\n', 'utf8' );
-	} catch ( error ) {
-		console.log( style.error( `Error while updating composer.json: ${ error.message }` ) );
-	}
-};
+const cleanupPackageJson = ( pkg ) => {
+	let changed = false;
 
-/**
- * Drop the `prepare` auto-trigger (so `npm install` no longer re-runs init) but
- * keep the `init` script so the feature manager stays re-runnable.
- *
- * @return {void}
- */
-const updatePackageJson = () => {
-	const packageJsonPath = path.resolve( getRoot(), 'package.json' );
-	try {
-		if ( ! fs.existsSync( packageJsonPath ) ) {
-			return;
-		}
-		const packageJson = JSON.parse( fs.readFileSync( packageJsonPath, 'utf8' ) );
-		const prepare = packageJson.scripts && packageJson.scripts.prepare;
-		if ( ! prepare || ! prepare.includes( 'npm run init' ) ) {
-			return;
-		}
+	const prepare = pkg.scripts && pkg.scripts.prepare;
+	if ( prepare && prepare.includes( 'npm run init' ) ) {
 		const remaining = prepare
 			.split( '&&' )
 			.map( ( script ) => script.trim() )
 			.filter( ( script ) => script !== 'npm run init' );
-
 		if ( remaining.length === 0 ) {
-			delete packageJson.scripts.prepare;
+			delete pkg.scripts.prepare;
 		} else {
-			packageJson.scripts.prepare = remaining.join( ' && ' );
+			pkg.scripts.prepare = remaining.join( ' && ' );
 		}
-		fs.writeFileSync( packageJsonPath, JSON.stringify( packageJson, null, '\t' ) + '\n', 'utf8' );
-	} catch ( error ) {
-		console.log( style.error( `Error while updating package.json: ${ error.message }` ) );
+		changed = true;
 	}
+
+	for ( const key of [ 'repository', 'bugs', 'homepage' ] ) {
+		if ( JSON.stringify( pkg[ key ] || '' ).includes( 'theme-elementary' ) ) {
+			delete pkg[ key ];
+			changed = true;
+		}
+	}
+
+	return changed;
 };
 
 /**
- * Delete first-run-only files. Keeps `bin/init.js` and `.wp-tooling.json` so the
- * feature manager remains re-runnable.
+ * Delete first-run-only files. Keeps `bin/init.js` and `.wp-tooling.json` so
+ * the feature manager remains re-runnable.
  *
+ * @param {boolean} keepGit Keep `.git` (a repo was created this run).
  * @return {void}
  */
-const runThemeCleanup = () => {
-	const toRemove = [ '.github', 'languages' ];
-	if ( ! isGitInitialized ) {
-		toRemove.push( '.git' );
-	}
+const removeScaffoldFiles = ( keepGit ) => {
+	const toRemove = [ '.github', 'languages', ...( keepGit ? [] : [ '.git' ] ) ];
 
 	let removed = 0;
 	for ( const entry of toRemove ) {
-		const target = path.resolve( getRoot(), entry );
+		const target = path.resolve( ROOT, entry );
 		try {
 			if ( fs.existsSync( target ) ) {
 				fs.rmSync( target, { recursive: true } );
@@ -641,7 +569,52 @@ const runThemeCleanup = () => {
 };
 
 /**
- * Recursively list project files, skipping VCS/build/dependency directories.
+ * Edit a JSON file in place, tab-indented like the rest of the repo.
+ *
+ * @param {string}   file   Path relative to the theme root.
+ * @param {Function} mutate Receives the parsed object; return false to skip writing.
+ * @return {void}
+ */
+const updateJsonFile = ( file, mutate ) => {
+	const filePath = path.resolve( ROOT, file );
+	try {
+		if ( ! fs.existsSync( filePath ) ) {
+			return;
+		}
+		const json = JSON.parse( fs.readFileSync( filePath, 'utf8' ) );
+		if ( mutate( json ) === false ) {
+			return;
+		}
+		fs.writeFileSync( filePath, JSON.stringify( json, null, '\t' ) + '\n', 'utf8' );
+	} catch ( error ) {
+		console.log( style.error( `Error while updating ${ file }: ${ error.message }` ) );
+	}
+};
+
+/**
+ * Apply a single regex replacement to a file, leaving the rest untouched.
+ *
+ * @param {string} file        Path relative to the theme root.
+ * @param {RegExp} pattern     Pattern to replace.
+ * @param {string} replacement Replacement string.
+ * @return {void}
+ */
+const replaceInFile = ( file, pattern, replacement ) => {
+	const filePath = path.resolve( ROOT, file );
+	try {
+		if ( ! fs.existsSync( filePath ) ) {
+			return;
+		}
+		const updated = fs.readFileSync( filePath, 'utf8' ).replace( pattern, replacement );
+		fs.writeFileSync( filePath, updated, 'utf8' );
+	} catch ( error ) {
+		console.log( style.error( `Error while updating ${ file }: ${ error.message }` ) );
+	}
+};
+
+/**
+ * Recursively list project files, skipping VCS/dependency directories.
+ * Symlinks are skipped so a broken link cannot abort the rename pass mid-way.
  *
  * @param {string} dir Directory to scan.
  * @return {string[]} Absolute file paths.
@@ -649,14 +622,14 @@ const runThemeCleanup = () => {
 const getAllFiles = ( dir ) => {
 	const ignore = [ '.git', '.github', 'node_modules', 'vendor' ];
 	const out = [];
-	for ( const entry of fs.readdirSync( dir ) ) {
-		if ( ignore.includes( entry ) ) {
+	for ( const entry of fs.readdirSync( dir, { withFileTypes: true } ) ) {
+		if ( ignore.includes( entry.name ) || entry.isSymbolicLink() ) {
 			continue;
 		}
-		const full = path.join( dir, entry );
-		if ( fs.statSync( full ).isDirectory() ) {
+		const full = path.join( dir, entry.name );
+		if ( entry.isDirectory() ) {
 			out.push( ...getAllFiles( full ) );
-		} else {
+		} else if ( entry.isFile() ) {
 			out.push( full );
 		}
 	}

--- a/bin/init.js
+++ b/bin/init.js
@@ -50,6 +50,7 @@ const main = async () => {
 
 	if ( args.length > 0 ) {
 		console.log( style.error( '\nInvalid arguments.\n' ) );
+		process.exitCode = 1;
 		return;
 	}
 
@@ -106,8 +107,8 @@ const scaffoldFlow = async () => {
 	} ) ) {
 		await initializeGit();
 	} else {
-		console.log( style.warning( '\nSkipping git initialization.' ) );
-		await askHooks();
+		// Git hooks require a repo, so skip the hooks prompt entirely here.
+		console.log( style.warning( '\nSkipping git initialization (and git hooks).' ) );
 	}
 
 	await themeCleanupFlow();
@@ -413,7 +414,7 @@ const writeProjectConfig = ( fields ) => {
 	try {
 		fs.writeFileSync(
 			path.resolve( getRoot(), CONFIG_FILE ),
-			JSON.stringify( config, null, 2 ) + '\n',
+			JSON.stringify( config, null, '\t' ) + '\n',
 			'utf8',
 		);
 		console.log( style.success( `Saved project config to ${ CONFIG_FILE }` ), '✨' );
@@ -532,7 +533,7 @@ const setPrepareScript = ( root ) => {
 		const pkg = JSON.parse( fs.readFileSync( packageJsonPath, 'utf8' ) );
 		pkg.scripts = pkg.scripts || {};
 		pkg.scripts.prepare = 'wp-tooling install-hooks || true';
-		fs.writeFileSync( packageJsonPath, JSON.stringify( pkg, null, 2 ), 'utf8' );
+		fs.writeFileSync( packageJsonPath, JSON.stringify( pkg, null, '\t' ) + '\n', 'utf8' );
 	} catch ( error ) {
 		// Non-fatal: hooks are still installed for this clone.
 	}
@@ -568,7 +569,7 @@ const updateComposerJson = () => {
 		if ( composerJson.scripts ) {
 			delete composerJson.scripts[ 'post-install-cmd' ];
 		}
-		fs.writeFileSync( composerJsonPath, JSON.stringify( composerJson, null, 2 ), 'utf8' );
+		fs.writeFileSync( composerJsonPath, JSON.stringify( composerJson, null, '\t' ) + '\n', 'utf8' );
 	} catch ( error ) {
 		console.log( style.error( `Error while updating composer.json: ${ error.message }` ) );
 	}
@@ -601,7 +602,7 @@ const updatePackageJson = () => {
 		} else {
 			packageJson.scripts.prepare = remaining.join( ' && ' );
 		}
-		fs.writeFileSync( packageJsonPath, JSON.stringify( packageJson, null, 2 ), 'utf8' );
+		fs.writeFileSync( packageJsonPath, JSON.stringify( packageJson, null, '\t' ) + '\n', 'utf8' );
 	} catch ( error ) {
 		console.log( style.error( `Error while updating package.json: ${ error.message }` ) );
 	}

--- a/bin/init.js
+++ b/bin/init.js
@@ -300,7 +300,10 @@ const applyThemeName = ( fields ) => {
 	const replacements = deriveReplacements( fields );
 	const replaceAll = ( value ) =>
 		replacements.reduce( ( out, [ search, replacement ] ) => out.split( search ).join( replacement ), value );
-	const files = getAllFiles( ROOT );
+	// Skip this script itself: it holds the search tokens verbatim (in
+	// deriveReplacements), and it is kept after scaffolding, so rewriting it
+	// would corrupt its own replacement table.
+	const files = getAllFiles( ROOT ).filter( ( file ) => file !== __filename );
 
 	const s = spinner( 'Applying your theme name across the project…' );
 	s.start();

--- a/bin/init.js
+++ b/bin/init.js
@@ -7,7 +7,7 @@
  *
  * First run (no `.wp-tooling.json`): rename the starter theme to your theme
  * name, persist the choices, pick optional features (Tailwind, ...), and
- * optionally set up git/husky. Later runs jump straight to the feature manager,
+ * optionally set up git + git hooks. Later runs jump straight to the feature manager,
  * so features can be toggled any time with `npm run init`.
  *
  * The whole flow runs on the wp-tooling TTY UI kit (text / confirm / spinner),
@@ -107,7 +107,7 @@ const scaffoldFlow = async () => {
 		await initializeGit();
 	} else {
 		console.log( style.warning( '\nSkipping git initialization.' ) );
-		await askHusky();
+		await askHooks();
 	}
 
 	await themeCleanupFlow();
@@ -444,7 +444,7 @@ const runFeatureManager = async ( { install = true } = {} ) => {
 };
 
 /**
- * Initialize git, set up husky between init and the first commit.
+ * Initialize git, install git hooks between init and the first commit.
  *
  * @return {Promise<void>}
  */
@@ -466,10 +466,10 @@ const initializeGit = async () => {
 		isGitInitialized = true;
 		s.succeed( 'Git initialized.' );
 
-		await askHusky();
+		await askHooks();
 
 		execSync( `git add '${ root }'`, { stdio: 'pipe' } );
-		// --no-verify so the husky pre-commit hook does not block the first commit.
+		// --no-verify so the commit-msg / pre-commit hooks do not block the first commit.
 		execSync(
 			"git commit -m 'Initialize project using https://github.com/rtCamp/theme-elementary' --no-verify",
 			{ cwd: root, stdio: 'pipe' },
@@ -480,57 +480,61 @@ const initializeGit = async () => {
 };
 
 /**
- * Ask whether to install Husky, then install it.
+ * Ask whether to install git hooks, then install them.
  *
  * @return {Promise<void>}
  */
-const askHusky = async () => {
-	if ( ! ( await confirm( { message: 'Would you like to install Husky?', defaultValue: true } ) ) ) {
-		console.log( style.warning( '\nSkipping Husky.\n' ) );
+const askHooks = async () => {
+	if ( ! ( await confirm( { message: 'Would you like to install git hooks (pre-commit lint + commit-msg)?', defaultValue: true } ) ) ) {
+		console.log( style.warning( '\nSkipping git hooks.\n' ) );
 		return;
 	}
-	installHusky();
+	await installGitHooks();
 };
 
 /**
- * Install Husky and wire the pre-commit lint hook.
+ * Install the wp-tooling git hooks (pre-commit runs `lint:staged`; commit-msg
+ * validates Conventional Commits) into `.git/hooks`, and point `prepare` at
+ * `wp-tooling install-hooks` so they reinstall after a fresh clone.
  *
- * @return {void}
+ * @return {Promise<void>}
  */
-const installHusky = () => {
+const installGitHooks = async () => {
 	const root = path.resolve( getRoot() );
 	if ( ! fs.existsSync( path.resolve( root, '.git' ) ) ) {
 		console.log( style.warning( '\nGit is not initialized. Please initialize git first.\n' ) );
 		return;
 	}
 
-	const s = spinner( 'Installing Husky…' );
+	const s = spinner( 'Installing git hooks…' );
 	s.start();
 	try {
-		execSync( `npm install husky@9.0.1 --save-dev --prefix '${ root }'`, { stdio: 'pipe' } );
-
-		// `husky init` overwrites the prepare script; preserve any existing one.
-		const packageJsonPath = path.resolve( root, 'package.json' );
-		let previousPrepare = '';
-		if ( fs.existsSync( packageJsonPath ) ) {
-			const pkg = JSON.parse( fs.readFileSync( packageJsonPath, 'utf8' ) );
-			previousPrepare = ( pkg.scripts && pkg.scripts.prepare ) || '';
-		}
-
-		execSync( 'npx husky init', { cwd: root, stdio: 'pipe' } );
-		fs.writeFileSync( path.resolve( root, '.husky/pre-commit' ), 'npm run lint:staged\n', 'utf8' );
-
-		if ( previousPrepare ) {
-			const pkg = JSON.parse( fs.readFileSync( packageJsonPath, 'utf8' ) );
-			if ( pkg.scripts && pkg.scripts.prepare ) {
-				pkg.scripts.prepare += ` && ${ previousPrepare }`;
-				fs.writeFileSync( packageJsonPath, JSON.stringify( pkg, null, 2 ), 'utf8' );
-			}
-		}
-
-		s.succeed( 'Husky installed.' );
+		const { installHooks } = require( '@rtcamp/wp-tooling/hooks' );
+		await installHooks( root, { force: true } );
+		setPrepareScript( root );
+		s.succeed( 'Git hooks installed (pre-commit + commit-msg).' );
 	} catch ( error ) {
-		s.fail( 'Error while installing Husky. Please check the logs above.' );
+		s.fail( `Could not install git hooks: ${ error.message }` );
+	}
+};
+
+/**
+ * Point the `prepare` lifecycle script at `wp-tooling install-hooks` so hooks
+ * reinstall after a fresh clone (`.git/hooks` is never committed). `|| true`
+ * keeps `npm install` from failing where there is no git repo (CI / tarball).
+ *
+ * @param {string} root Theme root.
+ * @return {void}
+ */
+const setPrepareScript = ( root ) => {
+	const packageJsonPath = path.resolve( root, 'package.json' );
+	try {
+		const pkg = JSON.parse( fs.readFileSync( packageJsonPath, 'utf8' ) );
+		pkg.scripts = pkg.scripts || {};
+		pkg.scripts.prepare = 'wp-tooling install-hooks || true';
+		fs.writeFileSync( packageJsonPath, JSON.stringify( pkg, null, 2 ), 'utf8' );
+	} catch ( error ) {
+		// Non-fatal: hooks are still installed for this clone.
 	}
 };
 

--- a/bin/init.js
+++ b/bin/init.js
@@ -17,7 +17,7 @@
 const fs = require( 'fs' );
 const path = require( 'path' );
 const { execSync } = require( 'child_process' );
-const { text, confirm, spinner, style } = require( '@rtcamp/wp-tooling/ui' );
+const { text, confirm, radio, spinner, style } = require( '@rtcamp/wp-tooling/ui' );
 
 const ROOT = path.resolve( __dirname, '..' );
 
@@ -33,7 +33,9 @@ const main = async () => {
 	const args = process.argv.slice( 2 );
 
 	if ( args.includes( '--clean' ) || args.includes( '-c' ) ) {
-		await themeCleanupFlow( { keepGit: false } );
+		// Standalone clean never touches `.git` — only the scaffold flow may
+		// remove the starter clone's repo (and its git prompt says so).
+		await themeCleanupFlow( { keepGit: true } );
 		return;
 	}
 
@@ -58,6 +60,8 @@ const main = async () => {
  * @return {Promise<void>}
  */
 const scaffoldFlow = async () => {
+	renderHeader();
+
 	if ( ! ( await confirm( { message: 'Would you like to set up the theme?', defaultValue: true } ) ) ) {
 		console.log( style.warning( '\nTheme setup cancelled.\n' ) );
 		return;
@@ -65,26 +69,28 @@ const scaffoldFlow = async () => {
 
 	const themeName = await text( {
 		message: 'Enter theme name (shown in WordPress admin)',
-		validate: required,
+		validate: validThemeName,
 	} );
 
-	// Review loop: declining the table opens a per-field editor. No cascade —
-	// editing one field never silently rewrites another.
+	// Review loop: declining the table opens a field picker — edit one field at
+	// a time, then re-confirm. No cascade: editing one never rewrites another.
 	let fields = defaultFields( themeName.trim() );
 	while ( true ) {
 		renderThemeDetails( fields );
 		if ( await confirm( { message: 'Confirm the theme details?', defaultValue: true } ) ) {
 			break;
 		}
-		console.log( style.info( '\nCustomize each field (press Enter to keep the shown value):' ) );
-		fields = await customizeFields( fields );
+		fields = await editFields( fields );
 	}
 
-	applyThemeName( fields );
+	const counts = applyThemeName( fields );
 	applyVersion( fields.version );
 	writeProjectConfig( fields );
+	// The theme is initialized now — drop the `prepare` auto-trigger so a later
+	// `npm install` cannot re-open init, even if the cleanup below is declined.
+	updateJsonFile( 'package.json', stripInitFromPrepare );
 
-	console.log( style.success( '\nChoose optional features for your theme:' ) );
+	console.log( style.bold( '\n  Optional features' ) );
 	// Init usually runs inside `npm install` (the prepare hook), so the feature
 	// manager records new deps in package.json instead of nesting an install.
 	await runFeatureManager( { install: false } );
@@ -101,14 +107,17 @@ const scaffoldFlow = async () => {
 
 	await themeCleanupFlow( { keepGit } );
 
-	console.log( style.success(
-		'\nAll set! If you enabled any features, run ' + style.warning( '`npm install`' ) +
-		style.success( ' once to install their dependencies.' ),
-	) );
-	console.log( style.success(
-		'Re-run ' + style.warning( '`npm run init`' ) +
-		style.success( ' any time to toggle features on or off.\n' ),
-	) );
+	renderSummary( fields, { ...counts, keepGit } );
+};
+
+/**
+ * Print the setup banner.
+ *
+ * @return {void}
+ */
+const renderHeader = () => {
+	console.log( style.bold( '\n  Theme setup' ) );
+	console.log( style.muted( '  Name your theme and pick optional features. Ctrl+C cancels.' ) );
 };
 
 /**
@@ -136,15 +145,6 @@ const toPascal = ( value ) => words( value ).map( cap ).join( '' );
 const toPascalSnake = ( value ) => words( value ).map( cap ).join( '_' );
 
 /**
- * Non-empty validator for text() prompts.
- *
- * @param {string} value
- * @return {string|undefined} Error message, or undefined when valid.
- */
-const required = ( value ) =>
-	value && value.trim() ? undefined : 'This field is required.';
-
-/**
  * Collapse doubled backslashes so a namespace pasted from composer.json
  * (`rtCamp\\Theme\\X`) behaves the same as one typed plainly, and strip
  * leading/trailing separators that would produce invalid PHP.
@@ -157,6 +157,52 @@ const normalizeNamespace = ( value ) =>
 		.trim()
 		.replace( /\\+/g, '\\' )
 		.replace( /^\\|\\$/g, '' );
+
+/*
+ * Per-field validators for text() prompts — each returns an error message or
+ * undefined. They guard the generated code: the theme name is substituted into
+ * single-quoted PHP strings (so no quotes/backslashes), a digit-leading prefix
+ * or text domain would produce invalid PHP/CSS identifiers, and a malformed
+ * namespace or package name corrupts composer.json. Validation runs on the raw
+ * input; derived values go through the same normalizers the replacements use.
+ */
+const validThemeName = ( value ) => {
+	const v = String( value ).trim();
+	if ( ! v ) {
+		return 'This field is required.';
+	}
+	if ( ! /^[A-Za-z]/.test( v ) ) {
+		return 'Start with a letter so the derived PHP/CSS identifiers stay valid.';
+	}
+	return /['"\\]/.test( v )
+		? 'Quotes and backslashes are not allowed — the name is written into PHP strings.'
+		: undefined;
+};
+
+const validVersion = ( value ) =>
+	/^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$/.test( String( value ).trim() )
+		? undefined
+		: 'Use a semantic version like 1.0.0.';
+
+const validTextDomain = ( value ) =>
+	/^[a-z][a-z0-9-]*$/.test( toKebab( value ) )
+		? undefined
+		: 'Must produce a kebab-case slug starting with a letter (e.g. my-theme).';
+
+const validNamespace = ( value ) =>
+	/^[A-Za-z_][A-Za-z0-9_]*(\\[A-Za-z_][A-Za-z0-9_]*)*$/.test( normalizeNamespace( value ) )
+		? undefined
+		: 'Use letters, numbers and underscores separated by \\ (e.g. rtCamp\\Theme\\MyTheme).';
+
+const validFunctionPrefix = ( value ) =>
+	/^[a-z][a-z0-9_]*$/.test( toSnake( value ) )
+		? undefined
+		: 'Must produce a snake_case prefix starting with a letter (e.g. my_theme).';
+
+const validPackageName = ( value ) =>
+	/^[a-z0-9]([a-z0-9._-]*[a-z0-9])?\/[a-z0-9]([a-z0-9._-]*[a-z0-9])?$/.test( String( value ).trim() )
+		? undefined
+		: 'Use the composer vendor/name format (lowercase, e.g. rtcamp/my-theme).';
 
 /**
  * Editable source fields, defaulted from the theme name. Everything else
@@ -196,22 +242,45 @@ const resolveIdentity = ( f ) => {
 	};
 };
 
+// Editable source fields: [ key, label, prompt, normalize, validate ]. Text
+// domain and prefix are normalised to kebab/snake so identifiers stay valid.
+const FIELD_META = [
+	[ 'themeName', 'Theme Name', 'Theme name', ( v ) => v.trim(), validThemeName ],
+	[ 'version', 'Version', 'Theme version', ( v ) => v.trim(), validVersion ],
+	[ 'textDomain', 'Text Domain', 'Text domain', toKebab, validTextDomain ],
+	[ 'namespace', 'Namespace', 'PHP namespace', ( v ) => v.trim(), validNamespace ],
+	[ 'functionPrefix', 'Function Prefix', 'Function / constant prefix', toSnake, validFunctionPrefix ],
+	[ 'packageName', 'Package', 'Composer package name', ( v ) => v.trim(), validPackageName ],
+];
+
 /**
- * Prompt for each editable field, defaulting to its current value (Enter
- * keeps it). Text domain and prefix are normalised to kebab/snake so the
- * generated identifiers stay valid.
+ * Field picker: pick one field to edit (defaulting to its current value),
+ * looping until "Done". Editing one field never rewrites another.
  *
- * @param {Object} f Current source fields.
+ * @param {Object} fields Current source fields.
  * @return {Promise<Object>} Updated source fields.
  */
-const customizeFields = async ( f ) => ( {
-	themeName: ( await text( { message: 'Theme name', defaultValue: f.themeName, validate: required } ) ).trim(),
-	version: ( await text( { message: 'Theme version', defaultValue: f.version, validate: required } ) ).trim(),
-	textDomain: toKebab( await text( { message: 'Text domain', defaultValue: f.textDomain, validate: required } ) ),
-	namespace: ( await text( { message: 'PHP namespace', defaultValue: f.namespace, validate: required } ) ).trim(),
-	functionPrefix: toSnake( await text( { message: 'Function / constant prefix', defaultValue: f.functionPrefix, validate: required } ) ),
-	packageName: ( await text( { message: 'Composer package name', defaultValue: f.packageName, validate: required } ) ).trim(),
-} );
+const editFields = async ( fields ) => {
+	const f = { ...fields };
+	const done = 'Done — back to summary';
+	while ( true ) {
+		const rows = FIELD_META.map( ( meta ) => ( {
+			meta,
+			text: `${ meta[ 1 ].padEnd( 16 ) }${ f[ meta[ 0 ] ] }`,
+		} ) );
+		const picked = await radio( {
+			message: 'Edit which field?',
+			choices: [ ...rows.map( ( r ) => r.text ), done ],
+		} );
+		if ( picked === done ) {
+			return f;
+		}
+		const [ key, , prompt, normalize, validate ] = rows.find( ( r ) => r.text === picked ).meta;
+		f[ key ] = normalize(
+			await text( { message: prompt, defaultValue: f[ key ], validate } ),
+		);
+	}
+};
 
 /**
  * Ordered [search, replacement] pairs applied literally (split/join, so the
@@ -254,39 +323,67 @@ const deriveReplacements = ( f ) => {
 };
 
 /**
- * Render the theme details table for confirmation. Values come from
- * {@link resolveIdentity}, so the table shows exactly what will be applied.
+ * Render the theme details box for confirmation. Two aligned columns, split
+ * into the identity you set and the values derived from it (dimmed). Values
+ * come from {@link resolveIdentity}, so the box shows exactly what is applied.
  *
  * @param {Object} fields Source fields.
  * @return {void}
  */
 const renderThemeDetails = ( fields ) => {
 	const id = resolveIdentity( fields );
-	const rows = Object.entries( {
-		'Theme Name': id.themeName,
-		'Theme Version': id.version,
-		'Text Domain': id.textDomain,
-		Package: id.packageName,
-		Namespace: id.namespace,
-		'Function Prefix': id.functionPrefix,
-		'CSS Class Prefix': id.cssClassPrefix,
-		'Version Constant': `${ id.constantPrefix }_VERSION`,
-		'Build Dir Constant': `${ id.constantPrefix }_BUILD_DIR`,
-		'Build URI Constant': `${ id.constantPrefix }_BUILD_URI`,
-	} ).map( ( [ label, value ] ) => [ `${ label }: `, value ] );
+	const identity = [
+		[ 'Theme Name', id.themeName ],
+		[ 'Version', id.version ],
+		[ 'Text Domain', id.textDomain ],
+		[ 'Package', id.packageName ],
+		[ 'Namespace', id.namespace ],
+		[ 'Function Prefix', id.functionPrefix ],
+	];
+	// Purely computed from the identity above — shown dimmed, never set directly.
+	const derived = [
+		[ 'CSS Class Prefix', id.cssClassPrefix ],
+		[ 'Constants', `${ id.constantPrefix }_{VERSION,BUILD_DIR,BUILD_URI}` ],
+	];
 
-	const width = Math.max( ...rows.map( ( [ label, value ] ) => label.length + value.length ) );
+	const PAD = 2; // padding inside the left border
+	const GAP = 2; // between the label and value columns
+	const all = [ ...identity, ...derived ];
+	const labelW = Math.max( ...all.map( ( [ label ] ) => label.length ) );
+	const valueW = Math.max( ...all.map( ( [ , value ] ) => value.length ) );
+	const inner = PAD + labelW + GAP + valueW + 1; // +1 trailing space
 
-	console.log( style.success( '\nTheme Details:' ) );
-	console.log( style.warning( `┌${ '─'.repeat( width + 2 ) }┐` ) );
-	for ( const [ label, value ] of rows ) {
-		const pad = ' '.repeat( width - label.length - value.length );
-		console.log(
-			style.warning( '│ ' ) + style.success( label ) + style.info( value ) + pad + style.warning( ' │' ),
-		);
+	// Build a row, computing the right-pad from the raw (un-styled) text so
+	// ANSI codes never throw off the border alignment.
+	const row = ( label, value, dim ) => {
+		const raw = ' '.repeat( PAD ) + label.padEnd( labelW ) + ' '.repeat( GAP ) + value;
+		const body = dim
+			? style.muted( raw )
+			: ' '.repeat( PAD ) + style.success( label.padEnd( labelW ) ) + ' '.repeat( GAP ) + style.info( value );
+		return style.muted( '│' ) + body + ' '.repeat( inner - raw.length ) + style.muted( '│' );
+	};
+	const rule = ( left, right ) => style.muted( '  ' + left + '─'.repeat( inner ) + right );
+
+	console.log( style.bold( '\n  Theme details' ) );
+	console.log( rule( '┌', '┐' ) );
+	for ( const [ label, value ] of identity ) {
+		console.log( '  ' + row( label, value, false ) );
 	}
-	console.log( style.warning( `└${ '─'.repeat( width + 2 ) }┘` ) );
+	console.log( rule( '├', '┤' ) );
+	for ( const [ label, value ] of derived ) {
+		console.log( '  ' + row( label, value, true ) );
+	}
+	console.log( rule( '└', '┘' ) );
 };
+
+// Contents of these are never search-replaced — decoding binary data as UTF-8
+// and writing it back corrupts it. Their *names* still go through the rename
+// pass (e.g. elementary-theme-logo.png).
+const BINARY_EXTENSIONS = new Set( [
+	'.png', '.jpg', '.jpeg', '.gif', '.webp', '.ico',
+	'.woff', '.woff2', '.ttf', '.eot', '.otf',
+	'.mo', '.zip', '.gz', '.jar', '.pdf',
+] );
 
 /**
  * Apply the identity across all project files — contents first, then
@@ -294,7 +391,7 @@ const renderThemeDetails = ( fields ) => {
  * Composer autoloader for the new namespace.
  *
  * @param {Object} fields Source fields.
- * @return {void}
+ * @return {{filesChanged: number, filesRenamed: number}} Counts for the summary.
  */
 const applyThemeName = ( fields ) => {
 	const replacements = deriveReplacements( fields );
@@ -313,6 +410,9 @@ const applyThemeName = ( fields ) => {
 
 	try {
 		for ( const file of files ) {
+			if ( BINARY_EXTENSIONS.has( path.extname( file ).toLowerCase() ) ) {
+				continue;
+			}
 			const original = fs.readFileSync( file, 'utf8' );
 			const updated = replaceAll( original );
 			if ( updated !== original ) {
@@ -344,6 +444,8 @@ const applyThemeName = ( fields ) => {
 	} catch {
 		dump.fail( 'Could not run `composer dump-autoload` — run it manually after installing dependencies.' );
 	}
+
+	return { filesChanged, filesRenamed };
 };
 
 /**
@@ -390,6 +492,53 @@ const writeProjectConfig = ( fields ) => {
 	} catch ( error ) {
 		console.log( style.error( `Error while writing ${ CONFIG_FILE }: ${ error.message }` ) );
 	}
+};
+
+/**
+ * Names of the features enabled in `.wp-tooling.json` (for the summary).
+ *
+ * @return {string[]} Enabled feature keys, or an empty array.
+ */
+const enabledFeatures = () => {
+	try {
+		const cfg = JSON.parse( fs.readFileSync( path.resolve( ROOT, CONFIG_FILE ), 'utf8' ) );
+		return Object.entries( cfg.features || {} ).filter( ( [ , on ] ) => on ).map( ( [ name ] ) => name );
+	} catch {
+		return [];
+	}
+};
+
+/**
+ * Print the closing recap: what was applied, plus the next steps.
+ *
+ * @param {Object}  fields              Source fields.
+ * @param {Object}  meta                Summary metadata.
+ * @param {number}  [meta.filesChanged] Files whose contents changed.
+ * @param {number}  [meta.filesRenamed] Files renamed.
+ * @param {boolean} [meta.keepGit]      Whether a git repo was initialized.
+ * @return {void}
+ */
+const renderSummary = ( fields, { filesChanged = 0, filesRenamed = 0, keepGit = false } = {} ) => {
+	const id = resolveIdentity( fields );
+	const features = enabledFeatures();
+	const rows = [
+		[ 'Name', id.themeName ],
+		[ 'Namespace', id.namespace ],
+		[ 'Files', `${ filesChanged } updated · ${ filesRenamed } renamed` ],
+		[ 'Features', features.length ? features.join( ', ' ) : 'none' ],
+		[ 'Git', keepGit ? 'initialized' : 'skipped' ],
+	];
+	const width = Math.max( ...rows.map( ( [ label ] ) => label.length ) );
+
+	console.log( style.bold( '\n  ✓ Setup complete' ) );
+	for ( const [ label, value ] of rows ) {
+		console.log( '    ' + style.muted( label.padEnd( width ) ) + '  ' + value );
+	}
+	console.log(
+		style.success( '\n  Next: ' ) + 'run ' + style.warning( '`npm install`' ) +
+		' to install feature deps, then ' + style.warning( '`npm start`' ) + '.',
+	);
+	console.log( style.muted( '  Re-run `npm run init` any time to toggle features on or off.\n' ) );
 };
 
 /**
@@ -507,29 +656,40 @@ const themeCleanupFlow = async ( { keepGit = false } = {} ) => {
 /**
  * Drop `npm run init` from the `prepare` script so `npm install` stops
  * re-running init (the `init` script itself stays so the feature manager
- * remains re-runnable), and remove repository/bugs/homepage entries still
- * pointing at the starter repo — they belong to theme-elementary, not the
- * scaffolded theme.
+ * remains re-runnable). Mutator for {@link updateJsonFile} — runs right after
+ * the project config is written, and again as a fallback during cleanup.
+ *
+ * @param {Object} pkg Parsed package.json.
+ * @return {boolean} False to skip writing when nothing changed.
+ */
+const stripInitFromPrepare = ( pkg ) => {
+	const prepare = pkg.scripts && pkg.scripts.prepare;
+	if ( ! prepare || ! prepare.includes( 'npm run init' ) ) {
+		return false;
+	}
+	const remaining = prepare
+		.split( '&&' )
+		.map( ( script ) => script.trim() )
+		.filter( ( script ) => script !== 'npm run init' );
+	if ( remaining.length === 0 ) {
+		delete pkg.scripts.prepare;
+	} else {
+		pkg.scripts.prepare = remaining.join( ' && ' );
+	}
+	return true;
+};
+
+/**
+ * Cleanup mutations for package.json: strip the init auto-trigger (fallback —
+ * normally already done post-init) and remove repository/bugs/homepage entries
+ * still pointing at the starter repo — they belong to theme-elementary, not
+ * the scaffolded theme.
  *
  * @param {Object} pkg Parsed package.json.
  * @return {boolean} False to skip writing when nothing changed.
  */
 const cleanupPackageJson = ( pkg ) => {
-	let changed = false;
-
-	const prepare = pkg.scripts && pkg.scripts.prepare;
-	if ( prepare && prepare.includes( 'npm run init' ) ) {
-		const remaining = prepare
-			.split( '&&' )
-			.map( ( script ) => script.trim() )
-			.filter( ( script ) => script !== 'npm run init' );
-		if ( remaining.length === 0 ) {
-			delete pkg.scripts.prepare;
-		} else {
-			pkg.scripts.prepare = remaining.join( ' && ' );
-		}
-		changed = true;
-	}
+	let changed = stripInitFromPrepare( pkg );
 
 	for ( const key of [ 'repository', 'bugs', 'homepage' ] ) {
 		if ( JSON.stringify( pkg[ key ] || '' ).includes( 'theme-elementary' ) ) {

--- a/docs/tailwind.md
+++ b/docs/tailwind.md
@@ -1,37 +1,55 @@
-# Tailwind CSS (opt-in)
+# Tailwind CSS (opt-in feature)
 
-Tailwind v4 support is opt-in. When enabled, `GenerateTailwindThemePlugin` reads `theme.json` and generates a `_tailwind-theme.css` file that maps WordPress preset tokens (colors, font sizes, font families, spacing) to Tailwind v4 utility namespaces.
+Tailwind v4 support is an **opt-in feature** managed through the theme's setup. When enabled,
+[`@rtcamp/tailwind-config`](https://github.com/rtCamp/wp-tooling)'s `GenerateTailwindThemePlugin`
+reads `theme.json` and generates `src/css/frontend/_tailwind-theme.css`, mapping WordPress preset
+tokens (colors, font sizes, font families, spacing) to Tailwind v4 utility namespaces. It also
+scaffolds `src/css/frontend/tailwind.css` (your editable entry point) on the first build.
 
-## Setup
+## Enable / disable it
 
-**1. Install the plugin package**
+Tailwind is toggled by the feature manager — run init at any time:
+
 ```bash
-npm install --save-dev @rtcamp/wp-tooling tailwindcss @tailwindcss/postcss
+npm run init
 ```
 
-**2. Configure PostCSS**
+On a fresh theme this runs during initial setup; on an already-initialized theme it jumps straight
+to the feature manager. Answer **yes** at the Tailwind prompt to enable it (or **no** to disable a
+previously enabled one). Enabling:
 
-Create or update `postcss.config.js` in the theme root:
-```js
-module.exports = require( '@rtcamp/wp-tooling/tailwind-config/postcss' );
-```
+- creates `postcss.config.js` (re-exporting `@rtcamp/tailwind-config/postcss`),
+- sets `"features": { "tailwind": true }` in `.wp-tooling.json` (read by `webpack.config.js`),
+- records the dev dependencies `@rtcamp/tailwind-config`, `tailwindcss`, `@tailwindcss/postcss`.
 
-**3. Add the plugin to `webpack.config.js`**
+After enabling, install the dependencies and build:
 
-In the `styles` compiler config, add `GenerateTailwindThemePlugin` to the plugins array:
-```js
-const { GenerateTailwindThemePlugin } = require( '@rtcamp/wp-tooling/tailwind-config' );
-
-// inside the styles config:
-plugins: [
-    new GenerateTailwindThemePlugin(),
-    // ...existing plugins
-],
-```
-
-**4. Generate and commit the entry file**
 ```bash
+npm install
 npm start
 ```
 
-This scaffolds `src/css/frontend/tailwind.css` (your editable entry point) and generates `src/css/frontend/_tailwind-theme.css` (auto-generated, do not edit). Commit `tailwind.css` — `_tailwind-theme.css` is gitignored and regenerated on every build.
+`npm start` runs `GenerateTailwindThemePlugin`, which writes `src/css/frontend/tailwind.css` (edit
+freely — committed) and `src/css/frontend/_tailwind-theme.css` (auto-generated on every build, kept
+out of git via `.gitignore`).
+
+Disabling (re-run `npm run init` and answer **no**) removes `postcss.config.js` and the generated
+`_tailwind-theme.css`, clears the flag so webpack stops loading the plugin, and asks before deleting
+your editable `tailwind.css`.
+
+## How it works
+
+- `webpack.config.js` reads `.wp-tooling.json` and only loads `GenerateTailwindThemePlugin` (from
+  `@rtcamp/tailwind-config`) in the styles compiler when `features.tailwind` is `true`. Toggling the
+  feature flips this flag — no manual webpack edits.
+- The compiled `assets/build/css/frontend/tailwind.css` is enqueued only when
+  `src/css/frontend/tailwind.css` exists (i.e. after the plugin has run at least once).
+- `watchOptions.ignored` excludes `assets/build/**` so Tailwind v4's content detection does not
+  trigger an infinite rebuild loop.
+
+## Manual setup (advanced)
+
+The feature manager is the supported path, but you can wire it by hand: install
+`@rtcamp/tailwind-config tailwindcss @tailwindcss/postcss`, add
+`module.exports = require('@rtcamp/tailwind-config/postcss');` to `postcss.config.js`, and set
+`{ "features": { "tailwind": true } }` in `.wp-tooling.json`.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 	"devDependencies": {
 		"@babel/core": "7.29.7",
 		"@eslint-community/eslint-plugin-eslint-comments": "4.7.2",
+		"@rtcamp/wp-tooling": "0.1.0",
 		"@wordpress/babel-preset-default": "8.47.0",
 		"@wordpress/browserslist-config": "6.47.0",
 		"@wordpress/env": "11.7.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -37,6 +37,41 @@ const [
 const rootPath = ( ...parts ) => path.resolve( process.cwd(), ...parts );
 
 /**
+ * Read the persisted theme config (`.wp-tooling.json`). Tolerant: returns an
+ * empty object when the file is missing or unreadable.
+ *
+ * @return {Object} Parsed config, or `{}`.
+ */
+const readThemeConfig = () => {
+	try {
+		return JSON.parse( fs.readFileSync( rootPath( '.wp-tooling.json' ), 'utf8' ) );
+	} catch {
+		return {};
+	}
+};
+
+const themeConfig = readThemeConfig();
+const tailwindEnabled = Boolean(
+	themeConfig.features && themeConfig.features.tailwind,
+);
+
+/**
+ * Tailwind plugins for the styles compiler, gated by the `tailwind` feature
+ * flag in `.wp-tooling.json` (toggled via `npm run init`). When off, the
+ * @rtcamp/tailwind-config package is never required, so themes that opt out do
+ * not need it installed.
+ *
+ * @return {Array} GenerateTailwindThemePlugin instance(s), or an empty array.
+ */
+const getTailwindPlugins = () => {
+	if ( ! tailwindEnabled ) {
+		return [];
+	}
+	const { GenerateTailwindThemePlugin } = require( '@rtcamp/tailwind-config' );
+	return [ new GenerateTailwindThemePlugin() ];
+};
+
+/**
  * Get a webpack plugin constructor name.
  *
  * The config filters by constructor name when it needs to remove or adjust a
@@ -430,6 +465,9 @@ const styles = {
 		...sharedNonHotConfig.module,
 	},
 	plugins: [
+		// Tailwind first: it scaffolds/regenerates the CSS entry files from
+		// theme.json before the compiler reads them.
+		...getTailwindPlugins(),
 		...sharedNonHotConfig.plugins.filter(
 			isNotOneOfPlugins( STYLE_ONLY_IGNORED_PLUGINS ),
 		),


### PR DESCRIPTION
## Description

Rewrites the theme init script (`bin/init.js`) into a **modular, re-runnable setup + feature manager** built on `@rtcamp/wp-tooling`. The first run scaffolds and renames the starter theme and persists its identity; later runs jump straight to a feature manager, so optional features (e.g. Tailwind) can be toggled on or off any time with `npm run init`.

## Technical Details

**Two modes, detected via `.wp-tooling.json`:**
- **Scaffold** (first run, no config): confirm intent → enter theme name → review/edit identity → search-replace tokens + rename files → `composer dump-autoload` → persist identity → pick optional features → optional git + git hooks → first-run cleanup.
- **Manage** (config exists): skip the rename and open the feature manager directly. Re-runnable.

**Key changes**
- Full rewrite onto the `@rtcamp/wp-tooling/ui` TTY kit (`text` / `confirm` / `spinner` / `style`) — replaces raw `readline` callbacks and hand-rolled ANSI codes.
- **Configurable identity:** declining the details table opens a per-field editor (Theme Name, Version, Text Domain, PHP Namespace, Function Prefix, Package Name), looping until confirmed. No cascade — editing one field never silently rewrites another.
- **Theme version is now applied** to `style.css` (`Version:` header) and `package.json` (`version`) — new behaviour.
- **Full project identity persisted** to `.wp-tooling.json` (name, version, textDomain, namespace, packageName, functionPrefix, cssClassPrefix, constantPrefix, cssDir, features). Reusable by any scaffold via `discover_from: "config:<key>"`.
- **Namespace rename fixed** (`rtCamp\Theme\Elementary`) plus cleanup of remaining bare-`elementary` identifiers; repo URLs / `elementary.local` examples are intentionally preserved.
- **Git hooks via `@rtcamp/wp-tooling` `installHooks()`** (pre-commit lint + commit-msg Conventional Commits) straight into `.git/hooks/` — **replaces Husky** (no `husky` dep, no `.husky/`). `prepare` is set to `wp-tooling install-hooks || true` so hooks reinstall after a fresh clone.
- **Feature management delegated** to `@rtcamp/wp-tooling/features`; the Tailwind scaffold is bundled in `@rtcamp/wp-tooling` (so it's shared across consumers) — the theme-local `bin/scaffolds/setup/tailwind/` is removed. `webpack.config.js` lazily gates `@rtcamp/tailwind-config` behind `features.tailwind`, so themes that opt out never need it installed.
- **Cleanup keeps** `bin/init.js` + `.wp-tooling.json` (so the feature manager stays re-runnable) and drops the `prepare → npm run init` auto-trigger so `npm install` no longer re-runs init.
- **Self-replacement guard:** `applyThemeName` skips its own file — `init.js` holds the search tokens verbatim and is now kept, so without this it would corrupt its own replacement table.
- **Hardening:** exits non-zero on unknown args, skips the hooks prompt when git is declined, and all JSON writes are tab-indented with a trailing newline.

> Depends on `@rtcamp/wp-tooling` (the engine-side feature-toggle layer + `discover_from` resolvers land in the wp-tooling repo). `@rtcamp/wp-tooling` and `@rtcamp/tailwind-config` are not published yet.

## Checklist

_(Acceptance criteria from #639 — verified via end-to-end smoke testing across default / custom-identity / Tailwind-toggle / edge-case runs.)_

- [x] `npm run init` scaffold flow works end-to-end with TTY prompts
- [x] Decline details → edit fields → confirm on second pass → all tokens use overridden values
- [x] `style.css` `Version:` and `package.json` `version` reflect the chosen version
- [x] `.wp-tooling.json` written with full identity; `discover_from: "config:<key>"` resolves
- [x] Feature manager opens, lists Tailwind, toggles on/off, creates/removes files
- [x] `bin/scaffolds/setup/tailwind/` removed (bundled scaffold used instead)
- [x] Pre-commit hook runs `npm run lint:staged` on commit
- [x] Commit-msg hook validates Conventional Commits
- [x] `npm run init --clean` works standalone
- [x] Non-TTY / piped stdin degrades gracefully (cancels cleanly on EOF)
- [x] Accepting all defaults (confirm on first pass) produces the same result as before
- [x] `bin/init.js` is not self-corrupted during the rename pass

## Screenshots

N/A — CLI-only change.

## To-do

- Merge the companion `@rtcamp/wp-tooling` change (feature-toggle layer + `discover_from` resolvers) first.
- Two separate packages are still unpublished: `@rtcamp/wp-tooling` (a devDependency of this theme) and `@rtcamp/tailwind-config` (added to the theme only when the Tailwind feature is enabled, with peers `tailwindcss` + `@tailwindcss/postcss`). Bump both to their published versions once available.

## Fixes/Covers issue

Fixes #639
