### PR TITLE
refactor(assets)!: replace AssetLoaderTrait with AssetLoader class

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/rtCamp/wp-framework.git",
-                "reference": "e3d6522692d091b2cc8014862413bd277a63aec2"
+                "reference": "b9475822e56b22ea59031357820a8092b8f2d910"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rtCamp/wp-framework/zipball/e3d6522692d091b2cc8014862413bd277a63aec2",
-                "reference": "e3d6522692d091b2cc8014862413bd277a63aec2",
+                "url": "https://api.github.com/repos/rtCamp/wp-framework/zipball/b9475822e56b22ea59031357820a8092b8f2d910",
+                "reference": "b9475822e56b22ea59031357820a8092b8f2d910",
                 "shasum": ""
             },
             "require": {
@@ -74,7 +74,7 @@
                 "issues": "https://github.com/rtCamp/wp-framework/issues",
                 "source": "https://github.com/rtCamp/wp-framework"
             },
-            "time": "2026-05-26T09:38:33+00:00"
+            "time": "2026-06-04T11:41:15+00:00"
         }
     ],
     "packages-dev": [
@@ -1208,11 +1208,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.55",
+            "version": "2.2.1",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/9eaac3826ed5e9b8427350a43cac825eeca3f566",
-                "reference": "9eaac3826ed5e9b8427350a43cac825eeca3f566",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/dea9c8f2d25cc849391042b71e429c1a4bf82660",
+                "reference": "dea9c8f2d25cc849391042b71e429c1a4bf82660",
                 "shasum": ""
             },
             "require": {
@@ -1234,6 +1234,17 @@
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ondřej Mirtes"
+                },
+                {
+                    "name": "Markus Staab"
+                },
+                {
+                    "name": "Vincent Langlet"
+                }
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
             "keywords": [
@@ -1257,7 +1268,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-18T11:57:34+00:00"
+            "time": "2026-05-28T14:44:12+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -1855,7 +1866,6 @@
                     "type": "github"
                 }
             ],
-            "abandoned": true,
             "time": "2020-10-26T13:08:54+00:00"
         },
         {
@@ -1911,7 +1921,6 @@
                     "type": "github"
                 }
             ],
-            "abandoned": true,
             "time": "2020-09-28T05:30:19+00:00"
         },
         {
@@ -3196,12 +3205,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/wp-cli.git",
-                "reference": "f041deb97d8637a1c78de8e9194125e05e35b466"
+                "reference": "49ad9e440b86ed46da49cc2062970ade9c4d798f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/f041deb97d8637a1c78de8e9194125e05e35b466",
-                "reference": "f041deb97d8637a1c78de8e9194125e05e35b466",
+                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/49ad9e440b86ed46da49cc2062970ade9c4d798f",
+                "reference": "49ad9e440b86ed46da49cc2062970ade9c4d798f",
                 "shasum": ""
             },
             "require": {
@@ -3272,7 +3281,7 @@
                 "issues": "https://github.com/wp-cli/wp-cli/issues",
                 "source": "https://github.com/wp-cli/wp-cli"
             },
-            "time": "2026-05-25T16:00:52+00:00"
+            "time": "2026-06-03T21:33:03+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -3447,6 +3456,6 @@
     "platform": {
         "php": ">=8.2"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "plugin-api-version": "2.6.0"
 }

--- a/inc/Core/Assets.php
+++ b/inc/Core/Assets.php
@@ -9,17 +9,18 @@ declare( strict_types = 1 );
 
 namespace rtCamp\Theme\Elementary\Core;
 
-use rtCamp\WPFramework\Contracts\Traits\AssetLoaderTrait;
+use rtCamp\WPFramework\AssetLoader;
 use rtCamp\WPFramework\Contracts\Interfaces\Registrable;
 
 /**
  * Class Assets
  *
+ * The theme's asset loader: extends the framework AssetLoader and registers
+ * the theme's own scripts and styles on the relevant hooks.
+ *
  * @since 1.0.0
  */
-class Assets implements Registrable {
-
-	use AssetLoaderTrait;
+class Assets extends AssetLoader implements Registrable {
 
 	/**
 	 * Whether Tailwind CSS is enabled for this theme.
@@ -46,9 +47,11 @@ class Assets implements Registrable {
 	 * Constructor.
 	 */
 	public function __construct() {
-		$this->base_dir   = trailingslashit( ELEMENTARY_THEME_PATH );
-		$this->base_url   = trailingslashit( get_template_directory_uri() );
-		$this->assets_dir = 'assets/build';
+		parent::__construct(
+			ELEMENTARY_THEME_PATH,
+			get_template_directory_uri(),
+			'assets/build'
+		);
 
 		$this->tailwind_enabled = (bool) apply_filters(
 			'elementary_theme_tailwind_enabled',


### PR DESCRIPTION

## What this does

Migrates the theme's `Assets` class onto the framework's new concrete
`AssetLoader`. The asset loader is now an object the theme **extends** rather
than a trait it mixes in. No behaviour change — the same scripts/styles register
on the same hooks.

## Changes

- `inc/Core/Assets.php`: `use AssetLoaderTrait` → `extends AssetLoader`;
  constructor now calls
  `parent::__construct( ELEMENTARY_THEME_PATH, get_template_directory_uri(), 'assets/build' )`.

## Breaking change / dependency

Requires `rtcamp/wp-framework` with `AssetLoader` (the trait has been removed).
**Depends on** rtCamp/wp-framework#34 — merge that first, then this resolves on
`dev-main`.

## How I verified

- PHPStan — no errors (against the framework branch with `AssetLoader`).
