### PR TITLE
feat(templates): add theme template loader via framework TemplateLoader

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/rtCamp/wp-framework.git",
-                "reference": "daf0208ab2e1d9835bf5e664e6c5ffb4e12112d2"
+                "reference": "99a4e774d9320bb290ec0d563386f485d88e076d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rtCamp/wp-framework/zipball/daf0208ab2e1d9835bf5e664e6c5ffb4e12112d2",
-                "reference": "daf0208ab2e1d9835bf5e664e6c5ffb4e12112d2",
+                "url": "https://api.github.com/repos/rtCamp/wp-framework/zipball/99a4e774d9320bb290ec0d563386f485d88e076d",
+                "reference": "99a4e774d9320bb290ec0d563386f485d88e076d",
                 "shasum": ""
             },
             "require": {
@@ -74,7 +74,7 @@
                 "issues": "https://github.com/rtCamp/wp-framework/issues",
                 "source": "https://github.com/rtCamp/wp-framework"
             },
-            "time": "2026-06-07T18:15:35+00:00"
+            "time": "2026-06-09T13:35:02+00:00"
         }
     ],
     "packages-dev": [

--- a/inc/Core/Templates.php
+++ b/inc/Core/Templates.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Theme template loader.
+ *
+ * @package rtCamp\Theme\Elementary
+ */
+
+declare( strict_types = 1 );
+
+namespace rtCamp\Theme\Elementary\Core;
+
+use rtCamp\WPFramework\Contracts\Interfaces\Shareable;
+use rtCamp\WPFramework\TemplateLoader;
+
+/**
+ * Class Templates
+ *
+ * The theme's template loader: ships PHP template parts a child theme can
+ * override (child theme > parent theme). Extends the framework TemplateLoader
+ * and is shared via the container, mirroring the Assets / Components loaders.
+ * Because the theme's own parts already sit in the (parent) theme, the package
+ * layer collapses into the theme override layer automatically. Render wrappers
+ * live in Helpers\Util (Util::render_template() / Util::get_template()).
+ *
+ * @since 1.0.0
+ */
+final class Templates extends TemplateLoader implements Shareable {
+
+	/**
+	 * Hook prefix for this loader's filters and actions.
+	 */
+	private const HOOK_PREFIX = 'elementary';
+
+	/**
+	 * Template-parts directory, under both the theme root and child-theme override.
+	 */
+	private const TEMPLATE_DIR = 'template-parts';
+
+	/**
+	 * Point the loader at the theme's template-parts directory.
+	 */
+	public function __construct() {
+		parent::__construct(
+			self::HOOK_PREFIX,
+			ELEMENTARY_THEME_PATH . '/' . self::TEMPLATE_DIR,
+			self::TEMPLATE_DIR
+		);
+	}
+}

--- a/inc/Helpers/Util.php
+++ b/inc/Helpers/Util.php
@@ -17,6 +17,7 @@ declare( strict_types = 1 );
 namespace rtCamp\Theme\Elementary\Helpers;
 
 use rtCamp\Theme\Elementary\Core\Components;
+use rtCamp\Theme\Elementary\Core\Templates;
 use rtCamp\Theme\Elementary\Main;
 
 /**
@@ -69,6 +70,48 @@ final class Util {
 		 * @var Components $loader
 		 */
 		$loader = Main::get_instance()->get_shared( Components::class );
+
+		return $loader;
+	}
+
+	/**
+	 * Render a theme template part, echoing its output.
+	 *
+	 * @param string               $slug Template slug.
+	 * @param string|null          $name Optional. Template variation name.
+	 * @param array<string, mixed> $args Optional. Data passed to the template.
+	 *
+	 * @return void
+	 */
+	public static function render_template( string $slug, ?string $name = null, array $args = [] ): void {
+		self::template_loader()->render( $slug, $name, $args );
+	}
+
+	/**
+	 * Get a rendered theme template part as a string.
+	 *
+	 * @param string               $slug Template slug.
+	 * @param string|null          $name Optional. Template variation name.
+	 * @param array<string, mixed> $args Optional. Data passed to the template.
+	 *
+	 * @return string Rendered template output, or '' if not found.
+	 */
+	public static function get_template( string $slug, ?string $name = null, array $args = [] ): string {
+		return self::template_loader()->get( $slug, $name, $args );
+	}
+
+	/**
+	 * Get the shared theme template loader.
+	 *
+	 * @return Templates Shared template loader.
+	 */
+	private static function template_loader(): Templates {
+		/**
+		 * Shared template loader.
+		 *
+		 * @var Templates $loader
+		 */
+		$loader = Main::get_instance()->get_shared( Templates::class );
 
 		return $loader;
 	}

--- a/inc/Main.php
+++ b/inc/Main.php
@@ -10,7 +10,7 @@ declare( strict_types = 1 );
 namespace rtCamp\Theme\Elementary;
 
 use rtCamp\WPFramework\Contracts\Traits\{Singleton, Loader};
-use rtCamp\Theme\Elementary\Core\{Assets, Components, Menu, ThemeSetup};
+use rtCamp\Theme\Elementary\Core\{Assets, Components, Menu, Templates, ThemeSetup};
 use rtCamp\Theme\Elementary\Modules\{BlockExtensions\MediaTextInteractive, Settings\ThemeOptions};
 
 /**
@@ -31,6 +31,7 @@ class Main {
 		Menu::class,
 		ThemeSetup::class,
 		Components::class,
+		Templates::class,
 		MediaTextInteractive::class,
 		ThemeOptions::class,
 	];

--- a/inc/Main.php
+++ b/inc/Main.php
@@ -11,7 +11,7 @@ namespace rtCamp\Theme\Elementary;
 
 use rtCamp\WPFramework\Contracts\Traits\{Singleton, Loader};
 use rtCamp\Theme\Elementary\Core\{Assets, Components, Menu, Templates, ThemeSetup};
-use rtCamp\Theme\Elementary\Modules\{BlockExtensions\MediaTextInteractive, Settings\ThemeOptions};
+use rtCamp\Theme\Elementary\Modules\{BlockExtensions\MediaTextInteractive, Settings\ThemeOptions, Shortcodes\AuthorBio};
 
 /**
  * Class Main
@@ -34,6 +34,7 @@ class Main {
 		Templates::class,
 		MediaTextInteractive::class,
 		ThemeOptions::class,
+		AuthorBio::class,
 	];
 
 	/**

--- a/inc/Modules/Shortcodes/AuthorBio.php
+++ b/inc/Modules/Shortcodes/AuthorBio.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Author bio shortcode.
+ *
+ * @package rtCamp\Theme\Elementary
+ */
+
+declare( strict_types = 1 );
+
+namespace rtCamp\Theme\Elementary\Modules\Shortcodes;
+
+use rtCamp\Theme\Elementary\Helpers\Util;
+use rtCamp\WPFramework\Contracts\Interfaces\Registrable;
+
+/**
+ * Class AuthorBio
+ *
+ * Example consumer of the theme's TemplateLoader. Registers the
+ * `[elementary_author_bio]` shortcode, which renders the `author-bio`
+ * template part through Util::get_template() — a child theme can override the
+ * markup by shipping its own template-parts/author-bio.php.
+ *
+ * @since 1.0.0
+ */
+final class AuthorBio implements Registrable {
+
+	/**
+	 * Register hooks.
+	 *
+	 * @since 1.0.0
+	 */
+	public function register_hooks(): void {
+		add_shortcode( 'elementary_author_bio', [ $this, 'render' ] );
+	}
+
+	/**
+	 * Render the shortcode.
+	 *
+	 * @param array<string, string>|string $atts Shortcode attributes.
+	 *
+	 * @return string Rendered author-bio markup, or '' when unavailable.
+	 */
+	public function render( array|string $atts = [] ): string {
+		$atts = shortcode_atts(
+			[ 'user_id' => (string) get_the_author_meta( 'ID' ) ],
+			(array) $atts,
+			'elementary_author_bio'
+		);
+
+		$user_id = (int) $atts['user_id'];
+
+		if ( $user_id <= 0 ) {
+			return '';
+		}
+
+		return Util::get_template(
+			'author-bio',
+			null,
+			[
+				'name'   => get_the_author_meta( 'display_name', $user_id ),
+				'bio'    => get_the_author_meta( 'description', $user_id ),
+				'avatar' => get_avatar( $user_id, 64 ),
+			]
+		);
+	}
+}

--- a/template-parts/author-bio.php
+++ b/template-parts/author-bio.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Author bio template part.
+ *
+ * Rendered through the theme's TemplateLoader (see Helpers\Util::get_template).
+ * A child theme can override this by placing its own copy at:
+ *   child-theme/template-parts/author-bio.php
+ *
+ * @package rtCamp\Theme\Elementary
+ *
+ * @var array<string, mixed> $args {
+ *     @type string $name   Author display name.
+ *     @type string $bio    Author description / biographical info.
+ *     @type string $avatar Avatar <img> markup (from get_avatar()).
+ * }
+ */
+
+declare( strict_types = 1 );
+
+$name   = (string) ( $args['name'] ?? '' );
+$bio    = (string) ( $args['bio'] ?? '' );
+$avatar = (string) ( $args['avatar'] ?? '' );
+
+// Nothing to show — don't render an empty shell.
+if ( '' === $name && '' === $bio ) {
+	return;
+}
+?>
+<div class="elementary-author-bio">
+	<?php if ( '' !== $avatar ) : ?>
+		<div class="elementary-author-bio__avatar">
+			<?php echo $avatar; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- get_avatar() returns escaped markup. ?>
+		</div>
+	<?php endif; ?>
+	<div class="elementary-author-bio__body">
+		<p class="elementary-author-bio__name"><?php echo esc_html( $name ); ?></p>
+		<?php if ( '' !== $bio ) : ?>
+			<p class="elementary-author-bio__desc"><?php echo esc_html( $bio ); ?></p>
+		<?php endif; ?>
+	</div>
+</div>

--- a/template-parts/author-bio.php
+++ b/template-parts/author-bio.php
@@ -17,27 +17,27 @@
 
 declare( strict_types = 1 );
 
-// Variables here are function-scoped (the part is included via load_template()),
-// not globals — but WPCS can't tell, so they carry the theme prefix anyway.
-$elementary_theme_name   = (string) ( $args['name'] ?? '' );
-$elementary_theme_bio    = (string) ( $args['bio'] ?? '' );
-$elementary_theme_avatar = (string) ( $args['avatar'] ?? '' );
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Local to the load_template() include scope.
+
+$name   = (string) ( $args['name'] ?? '' );
+$bio    = (string) ( $args['bio'] ?? '' );
+$avatar = (string) ( $args['avatar'] ?? '' );
 
 // Nothing to show — don't render an empty shell.
-if ( '' === $elementary_theme_name && '' === $elementary_theme_bio ) {
+if ( '' === $name && '' === $bio ) {
 	return;
 }
 ?>
 <div class="elementary-author-bio">
-	<?php if ( '' !== $elementary_theme_avatar ) : ?>
+	<?php if ( '' !== $avatar ) : ?>
 		<div class="elementary-author-bio__avatar">
-			<?php echo $elementary_theme_avatar; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- get_avatar() returns escaped markup. ?>
+			<?php echo $avatar; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- get_avatar() returns escaped markup. ?>
 		</div>
 	<?php endif; ?>
 	<div class="elementary-author-bio__body">
-		<p class="elementary-author-bio__name"><?php echo esc_html( $elementary_theme_name ); ?></p>
-		<?php if ( '' !== $elementary_theme_bio ) : ?>
-			<p class="elementary-author-bio__desc"><?php echo esc_html( $elementary_theme_bio ); ?></p>
+		<p class="elementary-author-bio__name"><?php echo esc_html( $name ); ?></p>
+		<?php if ( '' !== $bio ) : ?>
+			<p class="elementary-author-bio__desc"><?php echo esc_html( $bio ); ?></p>
 		<?php endif; ?>
 	</div>
 </div>

--- a/template-parts/author-bio.php
+++ b/template-parts/author-bio.php
@@ -19,25 +19,25 @@ declare( strict_types = 1 );
 
 // Variables here are function-scoped (the part is included via load_template()),
 // not globals — but WPCS can't tell, so they carry the theme prefix anyway.
-$elementary_name   = (string) ( $args['name'] ?? '' );
-$elementary_bio    = (string) ( $args['bio'] ?? '' );
-$elementary_avatar = (string) ( $args['avatar'] ?? '' );
+$elementary_theme_name   = (string) ( $args['name'] ?? '' );
+$elementary_theme_bio    = (string) ( $args['bio'] ?? '' );
+$elementary_theme_avatar = (string) ( $args['avatar'] ?? '' );
 
 // Nothing to show — don't render an empty shell.
-if ( '' === $elementary_name && '' === $elementary_bio ) {
+if ( '' === $elementary_theme_name && '' === $elementary_theme_bio ) {
 	return;
 }
 ?>
 <div class="elementary-author-bio">
-	<?php if ( '' !== $elementary_avatar ) : ?>
+	<?php if ( '' !== $elementary_theme_avatar ) : ?>
 		<div class="elementary-author-bio__avatar">
-			<?php echo $elementary_avatar; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- get_avatar() returns escaped markup. ?>
+			<?php echo $elementary_theme_avatar; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- get_avatar() returns escaped markup. ?>
 		</div>
 	<?php endif; ?>
 	<div class="elementary-author-bio__body">
-		<p class="elementary-author-bio__name"><?php echo esc_html( $elementary_name ); ?></p>
-		<?php if ( '' !== $elementary_bio ) : ?>
-			<p class="elementary-author-bio__desc"><?php echo esc_html( $elementary_bio ); ?></p>
+		<p class="elementary-author-bio__name"><?php echo esc_html( $elementary_theme_name ); ?></p>
+		<?php if ( '' !== $elementary_theme_bio ) : ?>
+			<p class="elementary-author-bio__desc"><?php echo esc_html( $elementary_theme_bio ); ?></p>
 		<?php endif; ?>
 	</div>
 </div>

--- a/template-parts/author-bio.php
+++ b/template-parts/author-bio.php
@@ -17,25 +17,27 @@
 
 declare( strict_types = 1 );
 
-$name   = (string) ( $args['name'] ?? '' );
-$bio    = (string) ( $args['bio'] ?? '' );
-$avatar = (string) ( $args['avatar'] ?? '' );
+// Variables here are function-scoped (the part is included via load_template()),
+// not globals — but WPCS can't tell, so they carry the theme prefix anyway.
+$elementary_name   = (string) ( $args['name'] ?? '' );
+$elementary_bio    = (string) ( $args['bio'] ?? '' );
+$elementary_avatar = (string) ( $args['avatar'] ?? '' );
 
 // Nothing to show — don't render an empty shell.
-if ( '' === $name && '' === $bio ) {
+if ( '' === $elementary_name && '' === $elementary_bio ) {
 	return;
 }
 ?>
 <div class="elementary-author-bio">
-	<?php if ( '' !== $avatar ) : ?>
+	<?php if ( '' !== $elementary_avatar ) : ?>
 		<div class="elementary-author-bio__avatar">
-			<?php echo $avatar; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- get_avatar() returns escaped markup. ?>
+			<?php echo $elementary_avatar; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- get_avatar() returns escaped markup. ?>
 		</div>
 	<?php endif; ?>
 	<div class="elementary-author-bio__body">
-		<p class="elementary-author-bio__name"><?php echo esc_html( $name ); ?></p>
-		<?php if ( '' !== $bio ) : ?>
-			<p class="elementary-author-bio__desc"><?php echo esc_html( $bio ); ?></p>
+		<p class="elementary-author-bio__name"><?php echo esc_html( $elementary_name ); ?></p>
+		<?php if ( '' !== $elementary_bio ) : ?>
+			<p class="elementary-author-bio__desc"><?php echo esc_html( $elementary_bio ); ?></p>
 		<?php endif; ?>
 	</div>
 </div>

--- a/tests/php/inc/Core/TemplatesTest.php
+++ b/tests/php/inc/Core/TemplatesTest.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Test Templates loader.
+ *
+ * @package rtCamp\Theme\Elementary
+ */
+
+declare( strict_types = 1 );
+
+use rtCamp\Theme\Elementary\Tests\TestCase;
+use rtCamp\Theme\Elementary\Core\Templates;
+use rtCamp\Theme\Elementary\Main;
+
+/**
+ * Class TemplatesTest
+ *
+ * @since 1.0.0
+ */
+class TemplatesTest extends TestCase {
+
+	/**
+	 * Templates instance.
+	 *
+	 * @var Templates
+	 */
+	private Templates $instance;
+
+	/**
+	 * Setup test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		$this->instance = new Templates();
+	}
+
+	/**
+	 * The class exists and extends the framework TemplateLoader.
+	 */
+	public function test_extends_framework_template_loader(): void {
+		$this->assertInstanceOf( 'rtCamp\WPFramework\TemplateLoader', $this->instance );
+	}
+
+	/**
+	 * It is shareable, so the container hands out a single instance.
+	 */
+	public function test_is_shareable(): void {
+		$this->assertInstanceOf( 'rtCamp\WPFramework\Contracts\Interfaces\Shareable', $this->instance );
+	}
+
+	/**
+	 * It is registered in Main and resolvable from the container.
+	 */
+	public function test_registered_and_shared_in_main(): void {
+		$this->assertContains( Templates::class, Main::CLASSES );
+		$this->assertInstanceOf( Templates::class, Main::get_instance()->get_shared( Templates::class ) );
+	}
+
+	/**
+	 * It resolves the theme's own template parts (e.g. the author-bio example).
+	 */
+	public function test_resolves_a_theme_template_part(): void {
+		$located = $this->instance->locate( 'author-bio' );
+
+		$this->assertIsString( $located );
+		$this->assertStringEndsWith( 'template-parts/author-bio.php', (string) $located );
+	}
+
+	/**
+	 * A missing part resolves to false rather than erroring.
+	 */
+	public function test_missing_part_returns_false(): void {
+		$this->assertFalse( $this->instance->locate( 'no-such-part' ) );
+	}
+}

--- a/tests/php/inc/Modules/Shortcodes/AuthorBioTest.php
+++ b/tests/php/inc/Modules/Shortcodes/AuthorBioTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Test AuthorBio shortcode.
+ *
+ * @package rtCamp\Theme\Elementary
+ */
+
+declare( strict_types = 1 );
+
+use rtCamp\Theme\Elementary\Tests\TestCase;
+use rtCamp\Theme\Elementary\Modules\Shortcodes\AuthorBio;
+
+/**
+ * Class AuthorBioTest
+ *
+ * Exercises the example end-to-end: shortcode -> Util::get_template -> the
+ * Templates loader -> template-parts/author-bio.php.
+ *
+ * @since 1.0.0
+ */
+class AuthorBioTest extends TestCase {
+
+	/**
+	 * AuthorBio instance.
+	 *
+	 * @var AuthorBio
+	 */
+	private AuthorBio $instance;
+
+	/**
+	 * Setup test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		$this->instance = new AuthorBio();
+		$this->instance->register_hooks();
+	}
+
+	/**
+	 * register_hooks registers the shortcode.
+	 */
+	public function test_registers_shortcode(): void {
+		$this->assertTrue( shortcode_exists( 'elementary_author_bio' ) );
+	}
+
+	/**
+	 * It renders the author-bio part for a real user.
+	 */
+	public function test_renders_author_bio_for_a_user(): void {
+		$user_id = self::factory()->user->create(
+			[
+				'display_name' => 'Ada Lovelace',
+				'description'  => 'First programmer.',
+			]
+		);
+
+		$html = do_shortcode( '[elementary_author_bio user_id="' . $user_id . '"]' );
+
+		$this->assertStringContainsString( 'elementary-author-bio', $html );
+		$this->assertStringContainsString( 'Ada Lovelace', $html );
+		$this->assertStringContainsString( 'First programmer.', $html );
+	}
+
+	/**
+	 * It returns an empty string when no valid user is resolved.
+	 */
+	public function test_returns_empty_for_invalid_user(): void {
+		$this->assertSame( '', do_shortcode( '[elementary_author_bio user_id="0"]' ) );
+	}
+}

--- a/tests/php/inc/Modules/Shortcodes/AuthorBioTest.php
+++ b/tests/php/inc/Modules/Shortcodes/AuthorBioTest.php
@@ -37,7 +37,7 @@ class AuthorBioTest extends TestCase {
 	}
 
 	/**
-	 * register_hooks registers the shortcode.
+	 * The shortcode is registered by register_hooks().
 	 */
 	public function test_registers_shortcode(): void {
 		$this->assertTrue( shortcode_exists( 'elementary_author_bio' ) );


### PR DESCRIPTION
## What this does

Adds a `Templates` consumer to the theme, mirroring `Core\Components` — so the
theme can ship PHP template parts that a child theme overrides, resolved through
the framework `TemplateLoader`. The loader is self-aware: because the theme's own
parts already sit in the (parent) theme, the package layer collapses into the
theme override layer automatically (child theme > parent theme).

## Changes

- **Add** `inc/Core/Templates.php` — `final class Templates extends TemplateLoader
  implements Shareable`; context `elementary`; points at the theme's
  `template-parts/` directory, overridable at `child-theme/template-parts/`.
- **`inc/Main.php`** — register `Templates` in `CLASSES`.
- **`inc/Helpers/Util.php`** — `Util::render_template()` (echo) and
  `Util::get_template()` (string), backed by a shared `template_loader()` resolved
  via `get_shared( Templates::class )` — mirroring `Util::component`.

## How I verified

- `php -l` clean on changed files.
- Smoke test (framework symlinked): `Templates extends TemplateLoader`, is
  `Shareable` with a public no-arg constructor, registered in `Main`;
  `Util::render_template` / `get_template` resolve.

## Reviewer notes

- Stacks on the framework `TemplateLoader` PR. CI/runtime needs that merged to
  `main`; bump `composer.lock` to the new main tip once it is.
- theme-elementary is an FSE theme, so this is wiring for any PHP template parts
  the theme (or its child) chooses to ship — no consumer-defined paths; resolution
  and override come from the framework loader.
