### PR TITLE
Add related posts module with SWR cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 	],
 	"require": {
 		"php": ">=8.2",
-		"rtcamp/wp-framework": "dev-main"
+		"rtcamp/wp-framework": "dev-feature/cache-utility"
 	},
 	"require-dev": {
 		"wp-coding-standards/wpcs": "^2.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "db06e940e3f311fbccbb71fc2828d672",
+    "content-hash": "723dc7332680de777d4a6de3a25af2d7",
     "packages": [
         {
             "name": "rtcamp/wp-framework",
-            "version": "dev-main",
+            "version": "dev-feature/cache-utility",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rtCamp/wp-framework.git",
-                "reference": "daf0208ab2e1d9835bf5e664e6c5ffb4e12112d2"
+                "reference": "e9a301f9554e17ff719575226ba6a773c8738953"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rtCamp/wp-framework/zipball/daf0208ab2e1d9835bf5e664e6c5ffb4e12112d2",
-                "reference": "daf0208ab2e1d9835bf5e664e6c5ffb4e12112d2",
+                "url": "https://api.github.com/repos/rtCamp/wp-framework/zipball/e9a301f9554e17ff719575226ba6a773c8738953",
+                "reference": "e9a301f9554e17ff719575226ba6a773c8738953",
                 "shasum": ""
             },
             "require": {
@@ -34,7 +34,6 @@
                 "wp-coding-standards/wpcs": "^3.1",
                 "yoast/phpunit-polyfills": "^4.0"
             },
-            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
@@ -74,7 +73,7 @@
                 "issues": "https://github.com/rtCamp/wp-framework/issues",
                 "source": "https://github.com/rtCamp/wp-framework"
             },
-            "time": "2026-06-07T18:15:35+00:00"
+            "time": "2026-06-08T10:20:45+00:00"
         }
     ],
     "packages-dev": [
@@ -3456,6 +3455,6 @@
     "platform": {
         "php": ">=8.2"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/inc/Main.php
+++ b/inc/Main.php
@@ -11,7 +11,7 @@ namespace rtCamp\Theme\Elementary;
 
 use rtCamp\WPFramework\Contracts\Traits\{Singleton, Loader};
 use rtCamp\Theme\Elementary\Core\{Assets, Components, Menu, ThemeSetup};
-use rtCamp\Theme\Elementary\Modules\{BlockExtensions\MediaTextInteractive, Settings\ThemeOptions};
+use rtCamp\Theme\Elementary\Modules\{BlockExtensions\MediaTextInteractive, RelatedPosts\RelatedPosts, Settings\ThemeOptions};
 
 /**
  * Class Main
@@ -33,6 +33,7 @@ class Main {
 		Components::class,
 		MediaTextInteractive::class,
 		ThemeOptions::class,
+		RelatedPosts::class,
 	];
 
 	/**

--- a/inc/Modules/RelatedPosts/RelatedPosts.php
+++ b/inc/Modules/RelatedPosts/RelatedPosts.php
@@ -59,8 +59,8 @@ class RelatedPosts implements Registrable {
 	 */
 	public function register_hooks(): void {
 		add_filter( 'the_content', [ $this, 'append_related_posts' ] );
-		add_action( 'save_post', [ $this, 'flush' ] );
-		add_action( 'deleted_post', [ $this, 'flush' ] );
+		add_action( 'save_post', [ $this, 'flush' ], 10, 2 );
+		add_action( 'deleted_post', [ $this, 'flush' ], 10, 2 );
 	}
 
 	/**
@@ -240,21 +240,24 @@ class RelatedPosts implements Registrable {
 	}
 
 	/**
-	 * Flush the related-posts cache group.
+	 * Flush the related-posts cache group when a post changes.
 	 *
-	 * Any post being saved or deleted can change which posts are related to
-	 * others, so the whole group is dropped rather than a single key. Revisions
-	 * and autosaves are ignored to avoid needless flushes.
+	 * Only `post` changes affect the related-posts query, so non-post saves and
+	 * deletes (pages, attachments, custom post types) are ignored — as are
+	 * revisions and autosaves, which carry the `revision` post type. The check
+	 * uses the WP_Post passed by the hook, so it stays reliable on `deleted_post`
+	 * too, where the row is already gone from the database.
 	 *
-	 * @param int $post_id Post being saved or deleted.
+	 * @param int          $post_id Post ID (the WP_Post argument is authoritative).
+	 * @param WP_Post|null $post    Post object supplied by save_post / deleted_post.
 	 *
 	 * @return void
 	 *
 	 * @action save_post
 	 * @action deleted_post
 	 */
-	public function flush( int $post_id = 0 ): void {
-		if ( $post_id > 0 && ( wp_is_post_revision( $post_id ) || wp_is_post_autosave( $post_id ) ) ) {
+	public function flush( int $post_id, ?WP_Post $post = null ): void {
+		if ( ! $post instanceof WP_Post || 'post' !== $post->post_type ) {
 			return;
 		}
 

--- a/inc/Modules/RelatedPosts/RelatedPosts.php
+++ b/inc/Modules/RelatedPosts/RelatedPosts.php
@@ -1,0 +1,263 @@
+<?php
+/**
+ * Related posts module.
+ *
+ * @package rtCamp\Theme\Elementary
+ */
+
+declare( strict_types = 1 );
+
+namespace rtCamp\Theme\Elementary\Modules\RelatedPosts;
+
+use rtCamp\WPFramework\Contracts\Interfaces\Registrable;
+use rtCamp\WPFramework\Utils\Cache;
+use rtCamp\Theme\Elementary\Helpers\Util;
+use WP_Post;
+use WP_Query;
+
+/**
+ * Class RelatedPosts
+ *
+ * Appends a "Related posts" section to single posts. Finding related posts is a
+ * taxonomy query — posts sharing the current post's categories or tags — which
+ * joins the term-relationship tables and is not cached by WordPress core. That
+ * lookup is the expensive, repeated, theme-owned operation, so its result is
+ * cached per post with {@see Cache::remember()} and rendered through the theme's
+ * Card component.
+ *
+ * Publishing or editing any post can change which posts are related to which, so
+ * the whole cache group is dropped on save/delete rather than a single key (see
+ * {@see flush()}); the per-entry TTL is only a backstop.
+ *
+ * @since 1.0.0
+ */
+class RelatedPosts implements Registrable {
+
+	/**
+	 * Object-cache group for related-post lookups.
+	 */
+	private const CACHE_GROUP = 'elementary_related_posts';
+
+	/**
+	 * Maximum number of related posts to show.
+	 */
+	private const LIMIT = 3;
+
+	/**
+	 * Guards against re-entrancy: rendering a related card calls
+	 * get_the_excerpt(), which re-applies the `the_content` filter — without this
+	 * flag the section would nest inside its own cards' excerpts.
+	 *
+	 * @var bool
+	 */
+	private bool $is_rendering = false;
+
+	/**
+	 * Register hooks.
+	 *
+	 * @since 1.0.0
+	 */
+	public function register_hooks(): void {
+		add_filter( 'the_content', [ $this, 'append_related_posts' ] );
+		add_action( 'save_post', [ $this, 'flush' ] );
+		add_action( 'deleted_post', [ $this, 'flush' ] );
+	}
+
+	/**
+	 * Append the related-posts section to the main single-post content.
+	 *
+	 * @param string $content Post content.
+	 *
+	 * @return string Content, with the related-posts section appended when applicable.
+	 *
+	 * @filter the_content
+	 */
+	public function append_related_posts( string $content ): string {
+		if ( $this->is_rendering ) {
+			return $content;
+		}
+
+		if ( ! is_singular( 'post' ) || ! in_the_loop() || ! is_main_query() ) {
+			return $content;
+		}
+
+		/**
+		 * Filters whether the related-posts section is appended to single posts.
+		 *
+		 * @param bool $show Whether to show related posts. Default true.
+		 */
+		if ( ! apply_filters( 'elementary_theme_show_related_posts', true ) ) {
+			return $content;
+		}
+
+		$post_id = get_the_ID();
+
+		if ( false === $post_id ) {
+			return $content;
+		}
+
+		$related = $this->get_related_post_ids( $post_id );
+
+		if ( empty( $related ) ) {
+			return $content;
+		}
+
+		$this->is_rendering = true;
+
+		try {
+			$section = $this->render( $related );
+		} finally {
+			$this->is_rendering = false;
+		}
+
+		return $content . $section;
+	}
+
+	/**
+	 * Get the IDs of posts related to the given post, cached per post.
+	 *
+	 * @param int $post_id Post to find related posts for.
+	 *
+	 * @return array<int, int> Related post IDs.
+	 */
+	public function get_related_post_ids( int $post_id ): array {
+		if ( $post_id <= 0 ) {
+			return [];
+		}
+
+		$related = Cache::remember(
+			"related_posts_{$post_id}",
+			fn (): array => $this->query_related_post_ids( $post_id ),
+			self::CACHE_GROUP,
+			DAY_IN_SECONDS
+		);
+
+		return is_array( $related ) ? $related : [];
+	}
+
+	/**
+	 * Run the (uncached) taxonomy query for related posts.
+	 *
+	 * Finds published posts that share a category or tag with $post_id, excluding
+	 * the post itself, most recent first.
+	 *
+	 * @param int $post_id Post to find related posts for.
+	 *
+	 * @return array<int, int> Related post IDs.
+	 */
+	private function query_related_post_ids( int $post_id ): array {
+		$category_ids = wp_get_post_categories( $post_id );
+		$tag_ids      = wp_get_post_tags( $post_id, [ 'fields' => 'ids' ] );
+
+		$category_ids = is_array( $category_ids ) ? $category_ids : [];
+		$tag_ids      = is_array( $tag_ids ) ? $tag_ids : [];
+
+		if ( empty( $category_ids ) && empty( $tag_ids ) ) {
+			return [];
+		}
+
+		$tax_query = [ 'relation' => 'OR' ];
+
+		if ( ! empty( $category_ids ) ) {
+			$tax_query[] = [
+				'taxonomy' => 'category',
+				'field'    => 'term_id',
+				'terms'    => $category_ids,
+			];
+		}
+
+		if ( ! empty( $tag_ids ) ) {
+			$tax_query[] = [
+				'taxonomy' => 'post_tag',
+				'field'    => 'term_id',
+				'terms'    => $tag_ids,
+			];
+		}
+
+		$query = new WP_Query(
+			[
+				'post_type'              => 'post',
+				'post_status'            => 'publish',
+				'posts_per_page'         => self::LIMIT, // phpcs:ignore WordPress.WP.PostsPerPage.posts_per_page_posts_per_page -- Bounded by a small constant (self::LIMIT).
+				'post__not_in'           => [ $post_id ], // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_post__not_in -- Excludes only the current post (a single ID), not an unbounded set.
+				'ignore_sticky_posts'    => true,
+				'no_found_rows'          => true,
+				'update_post_meta_cache' => false,
+				'update_post_term_cache' => false,
+				'fields'                 => 'ids',
+				'tax_query'              => $tax_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query -- The result is cached via Cache::remember(); see get_related_post_ids().
+			]
+		);
+
+		/**
+		 * Post IDs, since the query requests `fields => 'ids'`.
+		 *
+		 * @var array<int, int> $ids
+		 */
+		$ids = $query->posts;
+
+		return array_map( 'intval', $ids );
+	}
+
+	/**
+	 * Render the related-posts section as a list of Card components.
+	 *
+	 * @param array<int, int> $post_ids Related post IDs.
+	 *
+	 * @return string Section HTML, or empty string when nothing renders.
+	 */
+	private function render( array $post_ids ): string {
+		$cards = '';
+
+		foreach ( $post_ids as $post_id ) {
+			$post = get_post( $post_id );
+
+			if ( ! $post instanceof WP_Post ) {
+				continue;
+			}
+
+			// Card markup is escaped within the component itself.
+			$cards .= Util::get_component(
+				'Card',
+				[
+					'title'       => get_the_title( $post ),
+					'description' => wp_trim_words( get_the_excerpt( $post ), 20 ),
+					'image_url'   => (string) get_the_post_thumbnail_url( $post, 'elementary-featured' ),
+					'url'         => (string) get_permalink( $post ),
+				]
+			);
+		}
+
+		if ( '' === $cards ) {
+			return '';
+		}
+
+		return sprintf(
+			'<section class="elementary-related-posts"><h2 class="elementary-related-posts__title">%1$s</h2><div class="elementary-related-posts__grid">%2$s</div></section>',
+			esc_html__( 'Related posts', 'elementary-theme' ),
+			$cards
+		);
+	}
+
+	/**
+	 * Flush the related-posts cache group.
+	 *
+	 * Any post being saved or deleted can change which posts are related to
+	 * others, so the whole group is dropped rather than a single key. Revisions
+	 * and autosaves are ignored to avoid needless flushes.
+	 *
+	 * @param int $post_id Post being saved or deleted.
+	 *
+	 * @return void
+	 *
+	 * @action save_post
+	 * @action deleted_post
+	 */
+	public function flush( int $post_id = 0 ): void {
+		if ( $post_id > 0 && ( wp_is_post_revision( $post_id ) || wp_is_post_autosave( $post_id ) ) ) {
+			return;
+		}
+
+		Cache::flush_group( self::CACHE_GROUP );
+	}
+}

--- a/tests/php/inc/Modules/RelatedPosts/RelatedPostsTest.php
+++ b/tests/php/inc/Modules/RelatedPosts/RelatedPostsTest.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Test RelatedPosts module.
+ *
+ * @package rtCamp\Theme\Elementary
+ */
+
+declare( strict_types = 1 );
+
+use rtCamp\Theme\Elementary\Tests\TestCase;
+use rtCamp\Theme\Elementary\Modules\RelatedPosts\RelatedPosts;
+use rtCamp\WPFramework\Utils\Cache;
+
+/**
+ * Class RelatedPostsTest
+ *
+ * @since 1.0.0
+ */
+class RelatedPostsTest extends TestCase {
+
+	/**
+	 * RelatedPosts instance.
+	 *
+	 * @var RelatedPosts
+	 */
+	private RelatedPosts $instance;
+
+	/**
+	 * Setup test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		$this->instance = new RelatedPosts();
+	}
+
+	/**
+	 * Tear down test — drop the request-level cache so each test starts clean.
+	 */
+	public function tear_down(): void {
+		Cache::flush_runtime();
+		parent::tear_down();
+	}
+
+	/**
+	 * Test class exists.
+	 */
+	public function test_class_exists(): void {
+		$this->assertTrue( class_exists( RelatedPosts::class ) );
+	}
+
+	/**
+	 * Test class implements Registrable.
+	 */
+	public function test_implements_registrable(): void {
+		$this->assertInstanceOf( 'rtCamp\WPFramework\Contracts\Interfaces\Registrable', $this->instance );
+	}
+
+	/**
+	 * Test register_hooks wires the filter and actions.
+	 */
+	public function test_register_hooks(): void {
+		$this->instance->register_hooks();
+
+		$this->assertGreaterThan( 0, has_filter( 'the_content', [ $this->instance, 'append_related_posts' ] ) );
+		$this->assertGreaterThan( 0, has_action( 'save_post', [ $this->instance, 'flush' ] ) );
+		$this->assertGreaterThan( 0, has_action( 'deleted_post', [ $this->instance, 'flush' ] ) );
+	}
+
+	/**
+	 * Test related posts are found by a shared term, excluding self and unrelated posts.
+	 */
+	public function test_finds_related_posts_by_shared_term(): void {
+		$category_id = self::factory()->category->create();
+		$other_cat   = self::factory()->category->create();
+
+		$post_id   = self::factory()->post->create( [ 'post_category' => [ $category_id ] ] );
+		$related_a = self::factory()->post->create( [ 'post_category' => [ $category_id ] ] );
+		$related_b = self::factory()->post->create( [ 'post_category' => [ $category_id ] ] );
+		$unrelated = self::factory()->post->create( [ 'post_category' => [ $other_cat ] ] );
+
+		$ids = $this->instance->get_related_post_ids( $post_id );
+
+		$this->assertContains( $related_a, $ids );
+		$this->assertContains( $related_b, $ids );
+		$this->assertNotContains( $post_id, $ids, 'The current post must be excluded.' );
+		$this->assertNotContains( $unrelated, $ids, 'Posts with no shared term must be excluded.' );
+	}
+
+	/**
+	 * Test the related-post lookup is written through to the object cache.
+	 */
+	public function test_result_is_cached(): void {
+		$category_id = self::factory()->category->create();
+		$post_id     = self::factory()->post->create( [ 'post_category' => [ $category_id ] ] );
+		self::factory()->post->create( [ 'post_category' => [ $category_id ] ] );
+
+		$expected = $this->instance->get_related_post_ids( $post_id );
+
+		$found  = false;
+		$cached = Cache::get( "related_posts_{$post_id}", 'elementary_related_posts', true, $found );
+
+		$this->assertTrue( $found, 'The related-post IDs should be persisted to the object cache.' );
+		$this->assertSame( $expected, $cached );
+	}
+
+	/**
+	 * Test flush() drops the cached lookups from the group.
+	 */
+	public function test_flush_clears_cache(): void {
+		if ( ! function_exists( 'wp_cache_supports' ) || ! wp_cache_supports( 'flush_group' ) ) {
+			$this->markTestSkipped( 'Object cache backend does not support group flushing.' );
+		}
+
+		$category_id = self::factory()->category->create();
+		$post_id     = self::factory()->post->create( [ 'post_category' => [ $category_id ] ] );
+		self::factory()->post->create( [ 'post_category' => [ $category_id ] ] );
+
+		$this->instance->get_related_post_ids( $post_id );
+
+		// Drop the request layer so the assertion reads the object cache directly.
+		Cache::flush_runtime();
+		$this->instance->flush();
+
+		$found = false;
+		Cache::get( "related_posts_{$post_id}", 'elementary_related_posts', true, $found );
+
+		$this->assertFalse( $found, 'flush() should remove the cached lookup from the group.' );
+	}
+}

--- a/tests/php/inc/Modules/RelatedPosts/RelatedPostsTest.php
+++ b/tests/php/inc/Modules/RelatedPosts/RelatedPostsTest.php
@@ -119,11 +119,36 @@ class RelatedPostsTest extends TestCase {
 
 		// Drop the request layer so the assertion reads the object cache directly.
 		Cache::flush_runtime();
-		$this->instance->flush();
+		$this->instance->flush( $post_id, get_post( $post_id ) );
 
 		$found = false;
 		Cache::get( "related_posts_{$post_id}", 'elementary_related_posts', true, $found );
 
 		$this->assertFalse( $found, 'flush() should remove the cached lookup from the group.' );
+	}
+
+	/**
+	 * Test flush() ignores non-post types so unrelated saves do not evict the cache.
+	 */
+	public function test_flush_skips_non_post_types(): void {
+		if ( ! function_exists( 'wp_cache_supports' ) || ! wp_cache_supports( 'flush_group' ) ) {
+			$this->markTestSkipped( 'Object cache backend does not support group flushing.' );
+		}
+
+		$category_id = self::factory()->category->create();
+		$post_id     = self::factory()->post->create( [ 'post_category' => [ $category_id ] ] );
+		self::factory()->post->create( [ 'post_category' => [ $category_id ] ] );
+
+		$this->instance->get_related_post_ids( $post_id );
+		Cache::flush_runtime();
+
+		// Saving a page (or any non-post type) must NOT flush the post cache.
+		$page_id = self::factory()->post->create( [ 'post_type' => 'page' ] );
+		$this->instance->flush( $page_id, get_post( $page_id ) );
+
+		$found = false;
+		Cache::get( "related_posts_{$post_id}", 'elementary_related_posts', true, $found );
+
+		$this->assertTrue( $found, 'A non-post save must not flush the related-posts cache.' );
 	}
 }


### PR DESCRIPTION
## Description

Adds a "Related posts" section to single posts using the Card component, with SWR-cached taxonomy queries to avoid repeated DB lookups.

## Technical Details

- inc/Modules/RelatedPosts/RelatedPosts.php — Registrable module that appends related posts via the_content filter. Uses Cache::remember() with stale-while-revalidate to cache the WP_Query result per post (group elementary_related_posts, TTL DAY_IN_SECONDS).
- Cache invalidated on save_post/deleted_post for post type only — pages, CPTs, revisions, and autosaves are ignored.
- Post type gating uses the WP_Post hook parameter (reliable on deleted_post too, where the DB row is gone).
- Re-entrancy guard ($is_rendering with try/finally) prevents excerpt rendering from re-triggering the_content.
- Full PHPUnit test coverage at tests/php/inc/Modules/RelatedPosts/RelatedPostsTest.php.

## Checklist

<!--
If the ticket you worked on had any checklist, include that here and mark items that are covered in this PR. Else, create a checklist of all the items this PR covers.

Example:
- [ ] Fix incorrect meta key value for the Contact block.
- [ ] Fix footer button alignment issue.
-->
- [x] New `inc/Modules/RelatedPosts/RelatedPosts.php` implementing Registrable
- [x] SWR caching via `rtCamp\WPFramework\Utils\Cache::remember()`
- [x] Post-type-gated cache invalidation
- [x] Wired in `inc/Main.php::CLASSES`
- [x] PHPUnit tests for query, caching, flush, and post-type exclusion
- [x] Card component usage for rendering (escaping verified)

## Fixes/Covers issue

<!-- Add the issue number which the PR is intended to be for. -->
Part of https://github.com/rtcamp/wp-framework/issues/5

<!-- After you're done creating the PR, assign the PR to yourself and assign reviewers for the PR. If unsure about whom to ask for a review, leave blank and ping on the project-specific channel. -->
