### PR TITLE
feat(encryption): add a shared Encryption service over the framework Encryptor

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/rtCamp/wp-framework.git",
-                "reference": "99a4e774d9320bb290ec0d563386f485d88e076d"
+                "reference": "2e8fa2d5efd3940020b51b0a9c81f4488d3563eb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rtCamp/wp-framework/zipball/99a4e774d9320bb290ec0d563386f485d88e076d",
-                "reference": "99a4e774d9320bb290ec0d563386f485d88e076d",
+                "url": "https://api.github.com/repos/rtCamp/wp-framework/zipball/2e8fa2d5efd3940020b51b0a9c81f4488d3563eb",
+                "reference": "2e8fa2d5efd3940020b51b0a9c81f4488d3563eb",
                 "shasum": ""
             },
             "require": {
@@ -74,7 +74,7 @@
                 "issues": "https://github.com/rtCamp/wp-framework/issues",
                 "source": "https://github.com/rtCamp/wp-framework"
             },
-            "time": "2026-06-09T13:35:02+00:00"
+            "time": "2026-06-11T22:57:26+00:00"
         }
     ],
     "packages-dev": [

--- a/inc/Core/Encryption.php
+++ b/inc/Core/Encryption.php
@@ -31,7 +31,7 @@ final class Encryption extends Encryptor implements Shareable {
 	 *
 	 * @return string The encryption key.
 	 *
-	 * @throws \RuntimeException If ELEMENTARY_ENCRYPTION_KEY is not defined.
+	 * @throws \RuntimeException If ELEMENTARY_ENCRYPTION_KEY is not defined or is empty.
 	 */
 	protected function key(): string {
 		if ( defined( 'ELEMENTARY_ENCRYPTION_KEY' ) && '' !== ELEMENTARY_ENCRYPTION_KEY ) {

--- a/inc/Core/Encryption.php
+++ b/inc/Core/Encryption.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Theme encryption service.
+ *
+ * @package rtCamp\Theme\Elementary
+ */
+
+declare( strict_types = 1 );
+
+namespace rtCamp\Theme\Elementary\Core;
+
+use rtCamp\WPFramework\Contracts\Interfaces\Shareable;
+use rtCamp\WPFramework\Utils\Encryptor;
+
+/**
+ * Class Encryption
+ *
+ * The theme's shared Encryptor. Extends the framework Encryptor and sources the
+ * key via the key() seam from the ELEMENTARY_ENCRYPTION_KEY constant — define it
+ * in wp-config.php before using encryption. There is deliberately no salt
+ * fallback: an auth salt should not double as an encryption key, and rotating
+ * WordPress salts must not invalidate encrypted data. Shared through the
+ * container; call it through Helpers\Util (Util::encrypt() / Util::decrypt()).
+ *
+ * @since 1.0.0
+ */
+final class Encryption extends Encryptor implements Shareable {
+
+	/**
+	 * Resolve the theme's encryption key.
+	 *
+	 * @return string The encryption key.
+	 *
+	 * @throws \RuntimeException If ELEMENTARY_ENCRYPTION_KEY is not defined.
+	 */
+	protected function key(): string {
+		if ( defined( 'ELEMENTARY_ENCRYPTION_KEY' ) && '' !== ELEMENTARY_ENCRYPTION_KEY ) {
+			return (string) ELEMENTARY_ENCRYPTION_KEY;
+		}
+
+		return parent::key();
+	}
+}

--- a/inc/Helpers/Util.php
+++ b/inc/Helpers/Util.php
@@ -123,6 +123,8 @@ final class Util {
 	 * @param string $value Plaintext to encrypt.
 	 *
 	 * @return string|false Encrypted value, or false on failure.
+	 *
+	 * @throws \RuntimeException If ELEMENTARY_ENCRYPTION_KEY is not configured.
 	 */
 	public static function encrypt( string $value ): string|false {
 		return self::encryptor()->encrypt( $value );
@@ -134,6 +136,8 @@ final class Util {
 	 * @param string $value Encrypted value.
 	 *
 	 * @return string|false Decrypted value, or false on failure/tampering.
+	 *
+	 * @throws \RuntimeException If ELEMENTARY_ENCRYPTION_KEY is not configured.
 	 */
 	public static function decrypt( string $value ): string|false {
 		return self::encryptor()->decrypt( $value );

--- a/inc/Helpers/Util.php
+++ b/inc/Helpers/Util.php
@@ -17,6 +17,7 @@ declare( strict_types = 1 );
 namespace rtCamp\Theme\Elementary\Helpers;
 
 use rtCamp\Theme\Elementary\Core\Components;
+use rtCamp\Theme\Elementary\Core\Encryption;
 use rtCamp\Theme\Elementary\Main;
 
 /**
@@ -71,5 +72,43 @@ final class Util {
 		$loader = Main::get_instance()->get_shared( Components::class );
 
 		return $loader;
+	}
+
+	/**
+	 * Encrypt a value with the theme's shared Encryptor.
+	 *
+	 * @param string $value Plaintext to encrypt.
+	 *
+	 * @return string|false Encrypted value, or false on failure.
+	 */
+	public static function encrypt( string $value ): string|false {
+		return self::encryptor()->encrypt( $value );
+	}
+
+	/**
+	 * Decrypt a value produced by Util::encrypt().
+	 *
+	 * @param string $value Encrypted value.
+	 *
+	 * @return string|false Decrypted value, or false on failure/tampering.
+	 */
+	public static function decrypt( string $value ): string|false {
+		return self::encryptor()->decrypt( $value );
+	}
+
+	/**
+	 * Get the theme's shared Encryptor.
+	 *
+	 * @return Encryption Shared encryptor.
+	 */
+	private static function encryptor(): Encryption {
+		/**
+		 * Shared encryptor.
+		 *
+		 * @var Encryption $encryptor
+		 */
+		$encryptor = Main::get_instance()->get_shared( Encryption::class );
+
+		return $encryptor;
 	}
 }

--- a/inc/Main.php
+++ b/inc/Main.php
@@ -10,7 +10,7 @@ declare( strict_types = 1 );
 namespace rtCamp\Theme\Elementary;
 
 use rtCamp\WPFramework\Contracts\Traits\{Singleton, Loader};
-use rtCamp\Theme\Elementary\Core\{Assets, Components, Menu, ThemeSetup};
+use rtCamp\Theme\Elementary\Core\{Assets, Components, Encryption, Menu, ThemeSetup};
 use rtCamp\Theme\Elementary\Modules\{BlockExtensions\MediaTextInteractive, Settings\ThemeOptions};
 
 /**
@@ -31,6 +31,7 @@ class Main {
 		Menu::class,
 		ThemeSetup::class,
 		Components::class,
+		Encryption::class,
 		MediaTextInteractive::class,
 		ThemeOptions::class,
 	];

--- a/tests/php/inc/Core/EncryptionTest.php
+++ b/tests/php/inc/Core/EncryptionTest.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Test Encryption service.
+ *
+ * @package rtCamp\Theme\Elementary
+ */
+
+declare( strict_types = 1 );
+
+use rtCamp\Theme\Elementary\Tests\TestCase;
+use rtCamp\Theme\Elementary\Core\Encryption;
+use rtCamp\Theme\Elementary\Helpers\Util;
+use rtCamp\Theme\Elementary\Main;
+use rtCamp\WPFramework\Utils\Encryptor;
+
+/**
+ * Class EncryptionTest
+ *
+ * @since 1.0.0
+ */
+class EncryptionTest extends TestCase {
+
+	/**
+	 * The class exists and extends the framework Encryptor.
+	 */
+	public function test_extends_framework_encryptor(): void {
+		$this->assertInstanceOf( Encryptor::class, new Encryption() );
+	}
+
+	/**
+	 * It is shareable, registered in Main, and resolvable from the container.
+	 */
+	public function test_registered_and_shared_in_main(): void {
+		$this->assertContains( Encryption::class, Main::CLASSES );
+		$this->assertInstanceOf( Encryption::class, Main::get_instance()->get_shared( Encryption::class ) );
+	}
+
+	/**
+	 * A keyless framework Encryptor refuses to encrypt — the invariant the
+	 * service falls through to when ELEMENTARY_ENCRYPTION_KEY is missing.
+	 */
+	public function test_missing_key_throws(): void {
+		$this->expectException( RuntimeException::class );
+
+		( new Encryptor() )->encrypt( 'no key configured' );
+	}
+
+	/**
+	 * With the key constant defined, Util::encrypt() / Util::decrypt() roundtrip.
+	 */
+	public function test_encrypt_decrypt_roundtrips_with_key_constant(): void {
+		if ( ! defined( 'ELEMENTARY_ENCRYPTION_KEY' ) ) {
+			define( 'ELEMENTARY_ENCRYPTION_KEY', str_repeat( 'k', 32 ) );
+		}
+
+		$encrypted = Util::encrypt( 'sensitive-value' );
+
+		$this->assertIsString( $encrypted );
+		$this->assertNotSame( 'sensitive-value', $encrypted );
+		$this->assertSame( 'sensitive-value', Util::decrypt( $encrypted ) );
+	}
+
+	/**
+	 * Tampered ciphertext fails authentication and returns false (no throw).
+	 */
+	public function test_decrypt_returns_false_for_tampered_value(): void {
+		if ( ! defined( 'ELEMENTARY_ENCRYPTION_KEY' ) ) {
+			define( 'ELEMENTARY_ENCRYPTION_KEY', str_repeat( 'k', 32 ) );
+		}
+
+		$encrypted = Util::encrypt( 'secret' );
+		$this->assertIsString( $encrypted );
+
+		$decoded     = base64_decode( $encrypted, true );
+		$decoded[20] = 'A' === $decoded[20] ? 'B' : 'A';
+
+		$this->assertFalse( Util::decrypt( base64_encode( $decoded ) ) );
+	}
+}


### PR DESCRIPTION
## What this does

Wires the theme into the framework's instance-based `Encryptor`, following the
same consumer pattern as `Assets` / `Components` / `Templates`: a context-owned
`Core` service shared through the container, with `Util` wrappers as the call
surface.

## Changes

- **Add** `inc/Core/Encryption.php` — `final class Encryption extends Encryptor
  implements Shareable`; overrides the `key()` seam to source the key from the
  `ELEMENTARY_ENCRYPTION_KEY` constant. No salt fallback — without the constant
  the framework's `parent::key()` throws on first use.
- **`inc/Main.php`** — register `Encryption` in `CLASSES`.
- **`inc/Helpers/Util.php`** — `Util::encrypt()` / `Util::decrypt()` backed by a
  shared `encryptor()` resolved via `get_shared( Encryption::class )`.

## Configuration

Define a dedicated key in `wp-config.php` before first use:

```php
define( 'ELEMENTARY_ENCRYPTION_KEY', '<32+ bytes of random data>' );
```

There is deliberately **no `LOGGED_IN_KEY` fallback**: an auth salt should not
double as an encryption key, and rotating WordPress salts (standard incident
response) must never invalidate encrypted data. The throw is lazy — boot and
container registration never error; only an actual `Util::encrypt()` /
`Util::decrypt()` call without the constant does.

## How I verified

- `php -l` clean on changed files.
- Smoke test (framework branch symlinked): `Encryption extends Encryptor`, is
  `Shareable`; without the constant the first encrypt throws the framework's
  `RuntimeException`; with the constant a full encrypt → decrypt roundtrip
  succeeds.

## Reviewer notes

- Stacks on the framework Encryptor PR; bump `composer.lock` once it lands on
  `main`.
