### PR TITLE
refactor: name asset handles via AssetLoader::handle()

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/rtCamp/wp-framework.git",
-                "reference": "2e8fa2d5efd3940020b51b0a9c81f4488d3563eb"
+                "reference": "fa9a2b8feecc73cd484740c7d5acc8ff3dfb9bf5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rtCamp/wp-framework/zipball/2e8fa2d5efd3940020b51b0a9c81f4488d3563eb",
-                "reference": "2e8fa2d5efd3940020b51b0a9c81f4488d3563eb",
+                "url": "https://api.github.com/repos/rtCamp/wp-framework/zipball/fa9a2b8feecc73cd484740c7d5acc8ff3dfb9bf5",
+                "reference": "fa9a2b8feecc73cd484740c7d5acc8ff3dfb9bf5",
                 "shasum": ""
             },
             "require": {
@@ -28,10 +28,11 @@
                 "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
                 "phpcompatibility/phpcompatibility-wp": "^2.1",
                 "phpstan/phpstan": "^2.0",
-                "phpunit/phpunit": "^11.0",
+                "phpunit/phpunit": "^9.6",
                 "squizlabs/php_codesniffer": "^3.10",
                 "szepeviktor/phpstan-wordpress": "^2.0",
                 "wp-coding-standards/wpcs": "^3.1",
+                "wp-phpunit/wp-phpunit": "^6.9",
                 "yoast/phpunit-polyfills": "^4.0"
             },
             "default-branch": true,
@@ -74,7 +75,7 @@
                 "issues": "https://github.com/rtCamp/wp-framework/issues",
                 "source": "https://github.com/rtCamp/wp-framework"
             },
-            "time": "2026-06-11T22:57:26+00:00"
+            "time": "2026-06-19T12:37:08+00:00"
         }
     ],
     "packages-dev": [

--- a/inc/Core/Assets.php
+++ b/inc/Core/Assets.php
@@ -25,6 +25,12 @@ use rtCamp\WPFramework\Contracts\Interfaces\Shareable;
 class Assets extends AssetLoader implements Registrable, Shareable {
 
 	/**
+	 * Asset handle prefix, namespacing this theme's handles. Overrides the
+	 * framework default; read by AssetLoader::handle().
+	 */
+	public const HANDLE_PREFIX = 'elementary-theme-';
+
+	/**
 	 * Whether Tailwind CSS is enabled for this theme.
 	 *
 	 * Tailwind support is opt-in. It defaults to true when
@@ -81,12 +87,12 @@ class Assets extends AssetLoader implements Registrable, Shareable {
 	 * @action wp_enqueue_scripts
 	 */
 	public function register_assets(): void {
-		$this->register_script( 'core-navigation', 'js/frontend/core-navigation' );
-		$this->register_style( 'core-navigation', 'css/frontend/core-navigation' );
-		$this->register_style( 'elementary-theme-styles', 'css/frontend/styles' );
+		$this->register_script( $this->handle( 'core-navigation' ), 'js/frontend/core-navigation' );
+		$this->register_style( $this->handle( 'core-navigation' ), 'css/frontend/core-navigation' );
+		$this->register_style( $this->handle( 'styles' ), 'css/frontend/styles' );
 
 		if ( $this->tailwind_enabled ) {
-			$this->register_style( 'elementary-theme-tailwind', 'css/frontend/tailwind' );
+			$this->register_style( $this->handle( 'tailwind' ), 'css/frontend/tailwind' );
 		}
 	}
 
@@ -104,8 +110,8 @@ class Assets extends AssetLoader implements Registrable, Shareable {
 	 */
 	public function enqueue_block_specific_assets( string $markup, array $block ): string {
 		if ( ! empty( $block['blockName'] ) && 'core/navigation' === $block['blockName'] ) {
-			wp_enqueue_script( 'core-navigation' );
-			wp_enqueue_style( 'core-navigation' );
+			wp_enqueue_script( $this->handle( 'core-navigation' ) );
+			wp_enqueue_style( $this->handle( 'core-navigation' ) );
 		}
 
 		return $markup;
@@ -119,10 +125,10 @@ class Assets extends AssetLoader implements Registrable, Shareable {
 	 * @action wp_enqueue_scripts
 	 */
 	public function enqueue_assets(): void {
-		wp_enqueue_style( 'elementary-theme-styles' );
+		wp_enqueue_style( $this->handle( 'styles' ) );
 
 		if ( $this->tailwind_enabled ) {
-			wp_enqueue_style( 'elementary-theme-tailwind' );
+			wp_enqueue_style( $this->handle( 'tailwind' ) );
 		}
 	}
 
@@ -154,7 +160,7 @@ class Assets extends AssetLoader implements Registrable, Shareable {
 			$bs_url = "{$scheme}://{$host}:{$port}/browser-sync/browser-sync-client.js";
 		}
 
-		wp_enqueue_script( 'elementary-browser-sync', $bs_url, [], ELEMENTARY_THEME_VERSION, true );
+		wp_enqueue_script( $this->handle( 'browser-sync' ), $bs_url, [], ELEMENTARY_THEME_VERSION, true );
 	}
 
 	/**

--- a/tests/php/inc/Core/AssetsTest.php
+++ b/tests/php/inc/Core/AssetsTest.php
@@ -90,7 +90,7 @@ class AssetsTest extends TestCase {
 	}
 
 	/**
-	 * register_assets() registers styles/scripts under the prefixed handles.
+	 * Registers styles and scripts under the prefixed handles.
 	 */
 	public function test_register_assets_uses_prefixed_handles(): void {
 		// AssetLoader::register_script()/register_style() only register a handle

--- a/tests/php/inc/Core/AssetsTest.php
+++ b/tests/php/inc/Core/AssetsTest.php
@@ -56,4 +56,25 @@ class AssetsTest extends TestCase {
 		$this->assertGreaterThan( 0, has_action( 'wp_enqueue_scripts', [ $this->instance, 'enqueue_assets' ] ) );
 		$this->assertGreaterThan( 0, has_filter( 'render_block', [ $this->instance, 'enqueue_block_specific_assets' ] ) );
 	}
+
+	/**
+	 * Handles carry the theme prefix via the framework handle() helper.
+	 */
+	public function test_handles_are_prefixed(): void {
+		$this->assertSame( 'elementary-theme-', Assets::HANDLE_PREFIX );
+		$this->assertSame( 'elementary-theme-core-navigation', $this->instance->handle( 'core-navigation' ) );
+		$this->assertSame( 'elementary-theme-styles', $this->instance->handle( 'styles' ) );
+		$this->assertSame( 'elementary-theme-tailwind', $this->instance->handle( 'tailwind' ) );
+		$this->assertSame( 'elementary-theme-browser-sync', $this->instance->handle( 'browser-sync' ) );
+	}
+
+	/**
+	 * register_assets() registers styles/scripts under the prefixed handles.
+	 */
+	public function test_register_assets_uses_prefixed_handles(): void {
+		$this->instance->register_assets();
+
+		$this->assertTrue( wp_script_is( 'elementary-theme-core-navigation', 'registered' ) );
+		$this->assertTrue( wp_style_is( 'elementary-theme-styles', 'registered' ) );
+	}
 }

--- a/tests/php/inc/Core/AssetsTest.php
+++ b/tests/php/inc/Core/AssetsTest.php
@@ -25,11 +25,32 @@ class AssetsTest extends TestCase {
 	private Assets $instance;
 
 	/**
+	 * Build-asset fixture files created during a test, removed in tear_down().
+	 *
+	 * @var string[]
+	 */
+	private array $fixture_files = [];
+
+	/**
 	 * Setup test.
 	 */
 	public function set_up(): void {
 		parent::set_up();
 		$this->instance = new Assets();
+	}
+
+	/**
+	 * Remove any build-asset fixtures created during the test.
+	 */
+	public function tear_down(): void {
+		foreach ( $this->fixture_files as $file ) {
+			if ( file_exists( $file ) ) {
+				unlink( $file );
+			}
+		}
+		$this->fixture_files = [];
+
+		parent::tear_down();
 	}
 
 	/**
@@ -72,9 +93,35 @@ class AssetsTest extends TestCase {
 	 * register_assets() registers styles/scripts under the prefixed handles.
 	 */
 	public function test_register_assets_uses_prefixed_handles(): void {
+		// AssetLoader::register_script()/register_style() only register a handle
+		// when the built file exists on disk. The PHP unit-test job runs without a
+		// front-end build, so write the minimal built files register_assets()
+		// reads (removed again in tear_down()).
+		$this->write_build_asset( 'js/frontend/core-navigation.js' );
+		$this->write_build_asset( 'css/frontend/core-navigation.css' );
+		$this->write_build_asset( 'css/frontend/styles.css' );
+		$this->write_build_asset( 'css/frontend/tailwind.css' );
+
 		$this->instance->register_assets();
 
 		$this->assertTrue( wp_script_is( 'elementary-theme-core-navigation', 'registered' ) );
 		$this->assertTrue( wp_style_is( 'elementary-theme-styles', 'registered' ) );
+	}
+
+	/**
+	 * Write a fixture file under the theme's built-assets directory.
+	 *
+	 * @param string $relative Path relative to assets/build (e.g. js/frontend/core-navigation.js).
+	 */
+	private function write_build_asset( string $relative ): void {
+		$file = untrailingslashit( ELEMENTARY_THEME_PATH ) . '/assets/build/' . $relative;
+		$dir  = dirname( $file );
+
+		if ( ! is_dir( $dir ) ) {
+			wp_mkdir_p( $dir );
+		}
+
+		file_put_contents( $file, '/* test fixture */' );
+		$this->fixture_files[] = $file;
 	}
 }


### PR DESCRIPTION
Same handle cleanup as the plugin skeleton — drop the repeated literal handle strings for the framework's `handle()` helper plus a `HANDLE_PREFIX` override.

Two handles were named off-pattern (`core-navigation`, `elementary-browser-sync`); they now sit under the `elementary-theme-` prefix like everything else. Checked nothing references the old strings — they were only ever registered/enqueued in `Assets.php`.

Depends on the `AssetLoader::handle()` PR in wp-framework.
