### PR TITLE
feat(scaffold): selective example-set removal markers

### DIFF
--- a/bin/scaffold.config.js
+++ b/bin/scaffold.config.js
@@ -89,6 +89,47 @@ module.exports = {
 		},
 	],
 
+	// First-run "which example sets to remove?" prompt. The three module groups
+	// share inc/Main.php, so each scopes its own region with a keyed marker
+	// (wp:example:<key>); components and patterns are delete-only (auto-discovered,
+	// nothing to strip). Markers are stripped either way; code/files drop on remove.
+	examples: {
+		marker: 'wp:example',
+		groups: [
+			{
+				key: 'block-extension',
+				label: 'Media-text block extension',
+				marker: 'wp:example:block-extension',
+				strip: [ 'inc/Main.php' ],
+				remove: [ 'inc/Modules/BlockExtensions', 'patterns/media-text-interactive.php', 'src/js/frontend/modules/media-text.js' ],
+			},
+			{
+				key: 'settings',
+				label: 'Theme options settings page',
+				marker: 'wp:example:settings',
+				strip: [ 'inc/Main.php' ],
+				remove: [ 'inc/Modules/Settings' ],
+			},
+			{
+				key: 'shortcode',
+				label: 'Author bio shortcode',
+				marker: 'wp:example:shortcode',
+				strip: [ 'inc/Main.php' ],
+				remove: [ 'inc/Modules/Shortcodes', 'tests/php/inc/Modules/Shortcodes' ],
+			},
+			{
+				key: 'components',
+				label: 'Example components (button, card)',
+				remove: [ 'src/components/button', 'src/components/card' ],
+			},
+			{
+				key: 'patterns',
+				label: 'Page-creation pattern',
+				remove: [ 'patterns/page-creation-pattern.php' ],
+			},
+		],
+	},
+
 	cleanup: { targets: [ '.github', 'languages' ] },
 
 	docsUrl: 'https://github.com/rtCamp/theme-elementary/blob/main/README.md',

--- a/inc/Main.php
+++ b/inc/Main.php
@@ -11,7 +11,15 @@ namespace rtCamp\Theme\Elementary;
 
 use rtCamp\WPFramework\Contracts\Traits\{Singleton, Loader};
 use rtCamp\Theme\Elementary\Core\{Assets, Components, Encryption, Menu, Templates, ThemeSetup};
-use rtCamp\Theme\Elementary\Modules\{BlockExtensions\MediaTextInteractive, Settings\ThemeOptions, Shortcodes\AuthorBio};
+// wp:example:block-extension
+use rtCamp\Theme\Elementary\Modules\BlockExtensions\MediaTextInteractive;
+// wp:example:block-extension:end
+// wp:example:settings
+use rtCamp\Theme\Elementary\Modules\Settings\ThemeOptions;
+// wp:example:settings:end
+// wp:example:shortcode
+use rtCamp\Theme\Elementary\Modules\Shortcodes\AuthorBio;
+// wp:example:shortcode:end
 
 /**
  * Class Main
@@ -33,9 +41,15 @@ class Main {
 		Components::class,
 		Templates::class,
 		Encryption::class,
+		// wp:example:block-extension
 		MediaTextInteractive::class,
+		// wp:example:block-extension:end
+		// wp:example:settings
 		ThemeOptions::class,
+		// wp:example:settings:end
+		// wp:example:shortcode
 		AuthorBio::class,
+		// wp:example:shortcode:end
 	];
 
 	/**

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -108,6 +108,13 @@
 		<exclude-pattern>tests/*</exclude-pattern>
 	</rule>
 
+	<!-- The wp:example:* region markers in inc/Main.php are intentional scaffold tags
+	     (stripped by `npm run init`), not prose comments, so exempt just those lines
+	     from the inline-comment end-char rule. -->
+	<rule ref="Squiz.Commenting.InlineComment.InvalidEndChar">
+		<exclude-pattern>inc/Main.php</exclude-pattern>
+	</rule>
+
 	<rule ref="WordPress-VIP-Go">
 		<exclude-pattern>tests/*</exclude-pattern>
 	</rule>


### PR DESCRIPTION
## What this does

Marks the theme's demo code so `npm run init` can offer a per-set keep/remove choice on first scaffold.

## Changes

- `bin/scaffold.config.js` — `examples.groups`: the three demo modules (media-text block extension, theme options, author bio), the example components (button/card/carousel), and the page-creation pattern.
- `inc/Main.php` — the three demo modules share this file, so each scopes its own region with a keyed `wp:example:<key>` marker; the combined `use` is split so each import can be marked individually.

## How I verified

Ran the init engine's example step for remove-all, remove-subset (e.g. `settings,components`), and keep-all: keyed scoping removes only the chosen sets while keeping the rest, markers always stripped, `inc/Main.php` and all PHP valid (`php -l`).

## Notes

Markers are inert until init processes them — no runtime effect on the built theme. Components and the pattern are delete-only (auto-discovered, nothing to strip).
