### PR TITLE
chore: pre-public hardening — CONTRIBUTING + pin CI actions (v2)

### DIFF
--- a/.github/actions/setup-node-with-cache/action.yml
+++ b/.github/actions/setup-node-with-cache/action.yml
@@ -5,7 +5,7 @@ runs:
   using: 'composite'
   steps:
     - name: Setup Node
-      uses: actions/setup-node@v6.2.0
+      uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
       with:
         node-version-file: '.nvmrc'
 
@@ -16,7 +16,7 @@ runs:
 
     - name: Cache node_modules
       id: node_modules
-      uses: actions/cache@v5.0.3
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       with:
         path: '**/node_modules'
         key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json', '**/.npmrc') }}-${{ steps.node.outputs.version }}

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -23,7 +23,7 @@ jobs:
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Approve and merge the PR
         if: |
@@ -40,7 +40,7 @@ jobs:
     if: ${{ github.actor == 'rtBot' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Approve and merge the PR
         if: |

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -23,7 +23,7 @@ jobs:
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Approve and merge the PR
         if: |
@@ -40,7 +40,7 @@ jobs:
     if: ${{ github.actor == 'rtBot' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Approve and merge the PR
         if: |

--- a/.github/workflows/test-measure.yml
+++ b/.github/workflows/test-measure.yml
@@ -31,14 +31,14 @@ jobs:
       - name: Checkout including last 2 commits
         # Fetch last 2 commits if it's not a PR, so that we can determine the list of modified files.
         if: ${{ github.base_ref == null }}
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 2
 
       - name: Checkout
         # Do usual checkout if it's a PR.
         if: ${{ github.base_ref != null }}
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Fetch base branch
         # Only fetch base ref if it's a PR.
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Node with cache
         uses: ./.github/actions/setup-node-with-cache
@@ -123,7 +123,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Node with cache
         uses: ./.github/actions/setup-node-with-cache
@@ -138,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Node with cache
         uses: ./.github/actions/setup-node-with-cache
@@ -155,7 +155,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
@@ -196,7 +196,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Node with cache
         uses: ./.github/actions/setup-node-with-cache
@@ -226,7 +226,7 @@ jobs:
       WP_ENV_CORE: WordPress/WordPress#${{ matrix.wp }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Node with cache
         uses: ./.github/actions/setup-node-with-cache

--- a/.github/workflows/test-measure.yml
+++ b/.github/workflows/test-measure.yml
@@ -31,14 +31,14 @@ jobs:
       - name: Checkout including last 2 commits
         # Fetch last 2 commits if it's not a PR, so that we can determine the list of modified files.
         if: ${{ github.base_ref == null }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 2
 
       - name: Checkout
         # Do usual checkout if it's a PR.
         if: ${{ github.base_ref != null }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Fetch base branch
         # Only fetch base ref if it's a PR.
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Node with cache
         uses: ./.github/actions/setup-node-with-cache
@@ -123,7 +123,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Node with cache
         uses: ./.github/actions/setup-node-with-cache
@@ -138,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Node with cache
         uses: ./.github/actions/setup-node-with-cache
@@ -155,10 +155,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
           php-version: '8.2'
           coverage: none
@@ -170,7 +170,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Configure Composer cache
-        uses: actions/cache@v5.0.3
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -196,7 +196,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Node with cache
         uses: ./.github/actions/setup-node-with-cache
@@ -226,7 +226,7 @@ jobs:
       WP_ENV_CORE: WordPress/WordPress#${{ matrix.wp }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Node with cache
         uses: ./.github/actions/setup-node-with-cache

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing to Theme Elementary
+
+Thanks for your interest in improving Theme Elementary — a WordPress block
+starter theme built on the `rtcamp/wp-framework` package.
+
+## Development setup
+
+Requires Node 22 (`nvm use`) and PHP 8.2+.
+
+```bash
+nvm use
+composer install   # PHP dependencies + tooling (PHPCS, PHPStan)
+npm install        # build toolchain
+```
+
+## Building assets
+
+```bash
+npm start           # watch build (blocks + assets)
+npm run build:prod  # production build
+```
+
+## Before you open a PR
+
+Run the checks — all must pass:
+
+```bash
+npm run lint:all    # PHP (PHPCS) + JS (ESLint) + CSS (Stylelint)
+composer phpstan    # static analysis
+npm test            # JS + PHP test suites (PHP runs via @wordpress/env)
+```
+
+## Pull request checklist
+
+- [ ] `npm run lint:all` and `composer phpstan` pass.
+- [ ] `npm test` passes.
+- [ ] New/changed behavior is covered by tests.
+- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
+
+## License
+
+By contributing, you agree that your contributions are licensed under the
+project's [GPL-2.0](LICENSE) license.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ starter theme built on the `rtcamp/wp-framework` package.
 
 ## Development setup
 
-Requires Node 22 (`nvm use`) and PHP 8.2+.
+Requires the Node version in `.nvmrc` (`nvm use`) and PHP 8.2+.
 
 ```bash
 nvm use
@@ -40,4 +40,4 @@ npm test            # JS + PHP test suites (PHP runs via @wordpress/env)
 ## License
 
 By contributing, you agree that your contributions are licensed under the
-project's [GPL-2.0](LICENSE) license.
+project's [GPL-2.0-or-later](LICENSE) license.

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,18 @@
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 2 of the License, or (at your option) any later
+version.
+
+SPDX-License-Identifier: GPL-2.0-or-later
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+The full text of version 2 of the GNU General Public License follows.
+
+================================================================================
+
                     GNU GENERAL PUBLIC LICENSE
                        Version 2, June 1991
 

--- a/README.md
+++ b/README.md
@@ -1,139 +1,87 @@
-# Theme Elementary
+<h1 align="center">Theme Elementary</h1>
 
-![image](https://user-images.githubusercontent.com/59014930/187202051-df015d4a-f885-40cb-9fc9-c13991d3216d.png)
+<p align="center">
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-GPL--2.0-blue.svg" alt="License: GPL-2.0"></a>
+  <img src="https://img.shields.io/badge/PHP-8.2%2B-777bb4.svg" alt="PHP 8.2+">
+  <img src="https://img.shields.io/badge/WordPress-block%20theme-21759b.svg" alt="WordPress block theme">
+</p>
 
-A starter theme that facilitates a quick head start for developing new [block-based themes](https://developer.wordpress.org/block-editor/how-to-guides/themes/block-theme-overview/) along with a bunch of developer-friendly features.
+<p align="center">
+  A starter <a href="https://developer.wordpress.org/block-editor/how-to-guides/themes/block-theme-overview/">block theme</a>
+  that gives you a quick head start on new block-based themes, with a bunch of
+  developer-friendly features built in.
+</p>
 
-Reusable scaffolding (singleton, autoloader, asset loader, template loader, and abstract base classes) ships separately as the `rtcamp/wp-framework` Composer package and is loaded from `vendor/`.
+<p align="center">
+  <img src="https://user-images.githubusercontent.com/59014930/187202051-df015d4a-f885-40cb-9fc9-c13991d3216d.png" alt="Theme Elementary preview" width="100%">
+</p>
 
-> **Working on this theme?** See [DEVELOPMENT.md](DEVELOPMENT.md) for the architecture overview, the module pattern, and how to add new classes.
+---
 
-- [Understand the Folder Structure](#understand-the-folder-structure-open_file_folder)
-- [Get Started](#get-started-rocket)
-- [Development](#development-computer)
+Reusable scaffolding (singleton, autoloader, asset loader, template loader, and
+abstract base classes) ships separately as the
+[`rtcamp/wp-framework`](https://github.com/rtCamp/wp-framework) Composer package
+and is loaded from `vendor/`.
 
-## Understand the Folder Structure :open_file_folder:
-```
-.
-├── src (Frontend source)
-│   ├── css
-│   │   ├── frontend/
-│   │   ├── admin/
-│   │   ├── editor/
-│   │   ├── shared/
-│   │   ├── globals/
-│   │   └── mixins/
-│   ├── js
-│   │   ├── frontend/
-│   │   ├── admin/
-│   │   ├── editor/
-│   │   └── shared/
-│   ├── fonts/
-│   └── images/svg/
-├── assets
-│   └── build (Compiled output)
-├── bin (Holds scripts)
-├── functions.php (PHP entry point)
-├── inc (All project-specific PHP — PSR-4 root)
-│   ├── Autoloader.php (Wraps vendor/autoload.php with graceful failure)
-│   ├── Main.php (Theme bootstrap — loads services)
-│   ├── Helpers/ (Stateless static utility classes)
-│   ├── Core/ (Theme-wide infrastructure — assets, menus, theme setup)
-│   └── Modules/ (Feature areas)
-│       ├── BlockExtensions/ (Block render filters and integrations)
-│       └── Settings/ (Admin settings pages — extend AbstractSettingsPage)
-├── parts (Block Template Parts)
-├── patterns (Block Patterns)
-├── style.css
-├── templates (Block Templates)
-├── tests (Holds JS & PHP tests)
-│   ├── js/
-│   └── php/
-├── vendor
-│   └── rtcamp/wp-framework/ (Framework — do not modify; Composer-managed)
-├── DEVELOPMENT.md
-└── theme.json
+> **Working on this theme?** See [DEVELOPMENT.md](DEVELOPMENT.md) for the
+> architecture overview, the module pattern, and how to add new classes.
+> [CONTRIBUTING.md](CONTRIBUTING.md) covers the dev setup and PR flow.
+
+## Get started
+
+**Recommended** — scaffold a new project (runs `composer install && npm install`
+and a setup wizard that does the search-replace):
+
+```bash
+composer create-project rtcamp/elementary [folder-name]
 ```
 
-## Get Started :rocket:
+**Manual** — clone, then install and let the wizard run:
 
-### Method 1 (Recommended)
-```
-composer create-project rtcamp/elementary [folder_name]
-```
-This command is equivalent to cloning the repository and running `composer install && npm install`
-
-### Method 2
-Manually clone this repository using
-```
-git clone [URL to Git repo]
-```
-Having cloned this repository, install node packages and PHP dependencies using
-```
+```bash
+git clone <repo-url> && cd theme-elementary
 composer install
+npm install
 ```
 
-In both the methods, you will be prompted with a theme setup wizard which will help you with the search-replace. That was all! You're good to go with building your block theme. :sparkles:
+Use the Node version in `.nvmrc` (`nvm use`). That's it — you're ready to build
+your block theme. ✨
 
-**Note**: Refer to the `.nvmrc` file to check the supported Node.js version for running this project. If your current Node.js version does not run the project successfully on localhost, please use [Node Version Manager](https://github.com/nvm-sh/nvm) on your terminal to configure the right Node.js version.
-
-## Development :computer:
-
-
-**Production**
+## Development
 
 ```bash
-npm run build:prod
+npm start            # watch build
+npm run build:prod   # production build
+
+npm run lint:js      # + lint:css, lint:php (PHPCS)
+npm run lint:js:fix  # + lint:css:fix, lint:php:fix (PHPCBF)
+
+npm run test         # all tests; also test:js, test:js:watch, test:php
 ```
 
-**Watch changes**
+## Folder structure
 
-```bash
-npm start
+```
+functions.php               # PHP entry point
+inc/                        # project PHP (PSR-4 root)
+├── Autoloader.php          # wraps vendor/autoload.php with graceful failure
+├── Main.php                # theme bootstrap — loads services
+├── Helpers/                # stateless static utilities
+├── Core/                   # theme-wide infra — assets, menus, theme setup
+└── Modules/                # feature areas
+    ├── BlockExtensions/    # block render filters and integrations
+    └── Settings/           # admin settings pages (extend AbstractSettingsPage)
+src/{css,js,fonts,images}/  # frontend sources → assets/build/
+parts/ patterns/ templates/ # block parts, patterns, templates
+theme.json  style.css       # theme config
+tests/{js,php}/             # JS & PHP tests
+vendor/rtcamp/wp-framework/ # framework (Composer-managed; do not modify)
 ```
 
-**Linting & Formatting**
+## License
 
-Lint JS, CSS & PHP.
-```bash
-npm run lint:js
-npm run lint:css
-npm run lint:php #phpcs
-```
+[GPL-2.0](LICENSE)
 
-Auto fix fixable linting errors for JS, CSS & PHP.
-
-```bash
-npm run lint:js:fix
-npm run lint:css:fix
-npm run lint:php:fix #phpcbf
-```
-
-**Testing**
-
-Run all tests.
-
-```bash
-npm run test
-```
-
-Run JS tests.
-
-```bash
-npm run test:js
-```
-
-Watch JS tests.
-
-```bash
-npm run test:js:watch
-```
-
-Run PHP tests.
-
-```bash
-npm run test:php
-```
-
-## Does this interest you?
-<a href="https://rtcamp.com/"><img src="https://rtcamp.com/wp-content/uploads/sites/2/2019/04/github-banner@2x.png" alt="Join us at rtCamp, we specialize in providing high performance enterprise WordPress solutions"></a>
+<p align="center">
+  <a href="https://rtcamp.com"><img src="https://n8e0ka87m9.gdcdn.us/kfnbt046p8/GitHub_Banner.webp" alt="rtCamp — high-performance enterprise WordPress" width="100%"></a>
+</p>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align="center">Theme Elementary</h1>
 
 <p align="center">
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-GPL--2.0-blue.svg" alt="License: GPL-2.0"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-GPL--2.0--or--later-blue.svg" alt="License: GPL-2.0-or-later"></a>
   <img src="https://img.shields.io/badge/PHP-8.2%2B-777bb4.svg" alt="PHP 8.2+">
   <img src="https://img.shields.io/badge/WordPress-block%20theme-21759b.svg" alt="WordPress block theme">
 </p>
@@ -39,7 +39,7 @@ composer create-project rtcamp/elementary [folder-name]
 **Manual** — clone, then install and let the wizard run:
 
 ```bash
-git clone <repo-url> && cd theme-elementary
+git clone <repo-url> && cd <clone-dir>
 composer install
 npm install
 ```
@@ -80,7 +80,7 @@ vendor/rtcamp/wp-framework/ # framework (Composer-managed; do not modify)
 
 ## License
 
-[GPL-2.0](LICENSE)
+[GPL-2.0-or-later](LICENSE)
 
 <p align="center">
   <a href="https://rtcamp.com"><img src="https://n8e0ka87m9.gdcdn.us/kfnbt046p8/GitHub_Banner.webp" alt="rtCamp — high-performance enterprise WordPress" width="100%"></a>


### PR DESCRIPTION
## What this PR does

Pre-public hardening for the `theme-elementary-v2` deliverable line. Additive only — no theme code changes.

## Changes

- **Add `CONTRIBUTING.md`** — dev setup (nvm/composer/npm), the lint/analyse/test checks, and the PR checklist.
- **Pin CI actions to commit SHAs** — `actions/checkout`, `actions/cache`, `actions/setup-node` and `shivammathur/setup-php` were on mutable tags across `test-measure.yml`, `auto-merge.yml` and the `setup-node-with-cache` composite action; pinned to full SHAs (with version comments).

## Reviewer notes

- Not in this PR: `composer.json` requires `rtcamp/wp-framework: dev-main` from VCS — depend on the published Packagist version once wp-framework ships. The GitHub default branch is still `main`, not this v2 line (left per your call).
