### PR TITLE
ci: add PHPStan analysis job

### DIFF
--- a/.github/workflows/test-measure.yml
+++ b/.github/workflows/test-measure.yml
@@ -189,6 +189,43 @@ jobs:
       - name: Detect coding standard violations (PHPCS)
         run: vendor/bin/phpcs -q --report=checkstyle --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 | cs2pr --graceful-warnings
 
+  analyse-php:
+    needs: pre-run
+    if: needs.pre-run.outputs.changed-php-count > 0
+    name: 'PHPStan Analysis'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          coverage: none
+          github-token: ${{ secrets.WP_FRAMEWORK_REPO_TEMP_TOKEN }}
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Configure Composer cache
+        uses: actions/cache@v5.0.3
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Ensure git is installed
+        run: which git || (sudo apt-get update && sudo apt-get install -y git)
+
+      - name: Install Composer dependencies
+        run: composer install --prefer-dist --optimize-autoloader --no-progress --no-interaction --no-scripts
+
+      - name: Run PHPStan
+        run: composer phpstan
+
   build-prod:
     needs: pre-run
     if: needs.pre-run.outputs.changed-js-count > 0 || needs.pre-run.outputs.changed-css-count > 0

--- a/.github/workflows/test-measure.yml
+++ b/.github/workflows/test-measure.yml
@@ -181,6 +181,7 @@ jobs:
         run: which git || (sudo apt-get update && sudo apt-get install -y git)
 
       - name: Install Composer dependencies
+        id: composer-install
         run: composer install --prefer-dist --optimize-autoloader --no-progress --no-interaction --no-scripts
 
       - name: Validate composer.json
@@ -189,41 +190,9 @@ jobs:
       - name: Detect coding standard violations (PHPCS)
         run: vendor/bin/phpcs -q --report=checkstyle --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 | cs2pr --graceful-warnings
 
-  analyse-php:
-    needs: pre-run
-    if: needs.pre-run.outputs.changed-php-count > 0
-    name: 'PHPStan Analysis'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.2'
-          coverage: none
-          github-token: ${{ secrets.WP_FRAMEWORK_REPO_TEMP_TOKEN }}
-
-      - name: Get Composer Cache Directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-      - name: Configure Composer cache
-        uses: actions/cache@v5.0.3
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-
-
-      - name: Ensure git is installed
-        run: which git || (sudo apt-get update && sudo apt-get install -y git)
-
-      - name: Install Composer dependencies
-        run: composer install --prefer-dist --optimize-autoloader --no-progress --no-interaction --no-scripts
-
+      # Runs even when PHPCS fails, so one push surfaces both classes of error.
       - name: Run PHPStan
+        if: ${{ !cancelled() && steps.composer-install.conclusion == 'success' }}
         run: composer phpstan
 
   build-prod:


### PR DESCRIPTION
## Description

 Adds a PHPStan static analysis job to the `Test and Measure` workflow. The theme already ships a full PHPStan setup (`phpstan.neon.dist`, `phpstan-baseline.neon`, `phpstan-bootstrap.php`, and the PHPStan packages in `composer.json`), but nothing in CI was running it — so analysis only ever happened when someone remembered to run it locally. This wires it into the pipeline.

## Technical Details

New `analyse-php` job, modelled on the `analyse-php` job in `wp-framework`, but adapted to this repo's existing `lint-php` job so the two stay consistent:

- **Gated on `needs.pre-run.outputs.changed-php-count > 0`** — same signal as `lint-php`, so it only runs when PHP / `composer.*` / `phpstan.neon.dist` change. `wp-framework`'s version is ungated; this repo gates every job through `pre-run`.
- **Kept as a separate job rather than a step in `lint-php`** so PHPCS and PHPStan report independently and run in parallel.
- **`github-token` on `setup-php`** — required here (and absent from the `wp-framework` original) because `composer install` has to resolve the private `rtcamp/wp-framework` VCS dependency.
- **`composer phpstan`, not `composer analyse`** — this repo's script is named `phpstan` and expands to `phpstan analyse --memory-limit=1G`. The memory limit matters: at PHP's 128M default the analysis crashes with `PHPStan process crashed because it reached configured PHP memory limit: 128M`.
- **`--no-scripts` on `composer install`** — matches `lint-php` and skips the `post-install-cmd` `npm i`, which PHPStan doesn't need. Composer *plugins* still run under `--no-scripts`, so `phpstan/extension-installer` still registers the `phpstan-wordpress` and `phpstan-phpunit` extensions.
- PHP 8.2, Composer cache config, and the `Ensure git is installed` step are copied verbatim from `lint-php`.
  
## Checklist

- [x] Add `analyse-php` job running PHPStan in `Test and Measure`.
- [x] Gate the job on the existing `pre-run` changed-PHP signal.
- [x] Authenticate Composer for the private `rtcamp/wp-framework` dependency.
- [x] Verify the analysis currently passes with no errors.

<!-- After you're done creating the PR, assign the PR to yourself and assign reviewers for the PR. If unsure about whom to ask for a review, leave blank and ping on the project-specific channel. -->
