### PR TITLE
chore(deps): pin rtcamp/wp-framework to ^1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 	],
 	"require": {
 		"php": ">=8.2",
-		"rtcamp/wp-framework": "dev-main"
+		"rtcamp/wp-framework": "^1.0"
 	},
 	"require-dev": {
 		"wp-coding-standards/wpcs": "^2.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2cb40a71ad05e3074aa7f27c09214369",
+    "content-hash": "fc03e049ceadaf9e8cee4fb9a4657381",
     "packages": [
         {
             "name": "rtcamp/wp-framework",
-            "version": "dev-main",
+            "version": "v1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rtCamp/wp-framework.git",
-                "reference": "e30352cf578fcba49f889f801311b881cc368908"
+                "reference": "10f9a4d1fd9d2d56e2cd477605253e82a1317039"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rtCamp/wp-framework/zipball/e30352cf578fcba49f889f801311b881cc368908",
-                "reference": "e30352cf578fcba49f889f801311b881cc368908",
+                "url": "https://api.github.com/repos/rtCamp/wp-framework/zipball/10f9a4d1fd9d2d56e2cd477605253e82a1317039",
+                "reference": "10f9a4d1fd9d2d56e2cd477605253e82a1317039",
                 "shasum": ""
             },
             "require": {
@@ -32,10 +32,9 @@
                 "squizlabs/php_codesniffer": "^3.10",
                 "szepeviktor/phpstan-wordpress": "^2.0",
                 "wp-coding-standards/wpcs": "^3.1",
-                "wp-phpunit/wp-phpunit": "^6.9",
+                "wp-phpunit/wp-phpunit": "^6.9 || ^7.0",
                 "yoast/phpunit-polyfills": "^4.0"
             },
-            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
@@ -75,7 +74,7 @@
                 "issues": "https://github.com/rtCamp/wp-framework/issues",
                 "source": "https://github.com/rtCamp/wp-framework"
             },
-            "time": "2026-06-23T22:36:13+00:00"
+            "time": "2026-07-27T19:49:48+00:00"
         }
     ],
     "packages-dev": [
@@ -3449,15 +3448,13 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {
-        "rtcamp/wp-framework": 20
-    },
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": ">=8.2"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "platform-overrides": {
         "php": "8.2"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "rtcamp/wp-framework",
-            "version": "v1.0.0",
+            "version": "v1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rtCamp/wp-framework.git",
-                "reference": "10f9a4d1fd9d2d56e2cd477605253e82a1317039"
+                "reference": "87774ee10d2e10f5b8bd2561a5d8e4a92f431b8d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rtCamp/wp-framework/zipball/10f9a4d1fd9d2d56e2cd477605253e82a1317039",
-                "reference": "10f9a4d1fd9d2d56e2cd477605253e82a1317039",
+                "url": "https://api.github.com/repos/rtCamp/wp-framework/zipball/87774ee10d2e10f5b8bd2561a5d8e4a92f431b8d",
+                "reference": "87774ee10d2e10f5b8bd2561a5d8e4a92f431b8d",
                 "shasum": ""
             },
             "require": {
@@ -74,7 +74,7 @@
                 "issues": "https://github.com/rtCamp/wp-framework/issues",
                 "source": "https://github.com/rtCamp/wp-framework"
             },
-            "time": "2026-07-27T19:49:48+00:00"
+            "time": "2026-07-29T11:38:56+00:00"
         }
     ],
     "packages-dev": [

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -34,6 +34,8 @@ parameters:
 			- tests/
 			- vendor/
 		analyseAndScan:
-			- node_modules/
+			# Optional: the Lint PHP job never runs `npm install`, so this path is
+			# absent there and PHPStan treats a missing excludePath as a config error.
+			- node_modules/ (?)
 	scanFiles:
 		- vendor/php-stubs/wp-cli-stubs/wp-cli-stubs.php


### PR DESCRIPTION
## What

Pins `rtcamp/wp-framework` to `^1.0` instead of `dev-main`, resolving to the tagged [v1.0.1](https://github.com/rtCamp/wp-framework/releases/tag/v1.0.1) release.

```diff
-"rtcamp/wp-framework": "dev-main"
+"rtcamp/wp-framework": "^1.0"
```

## Why

`dev-main` is a moving target. Every `composer install` resolved to whatever the framework's `main` branch was at that moment — builds weren't reproducible, and nothing protected the theme from a breaking change landing upstream.

That's not hypothetical: this PR originally locked to v1.0.0 and the whole PHP matrix fataled on boot —

```
Access to undeclared static property rtCamp\Theme\Elementary\Main::$instance
#0 .../wp-framework/inc/Contracts/Traits/Singleton.php(48): Main->__construct()
#1 .../theme-elementary/functions.php(52): Main::get_instance()
```

v1.0.0 had changed the `Singleton` trait's storage, removing the `protected static $instance` property this theme assigns in its constructor ([inc/Main.php:47](https://github.com/rtCamp/theme-elementary/blob/theme-elementary-v2/inc/Main.php#L47)). That assignment is the re-entrancy guard for our constructor-driven Loader, so it wasn't safe to just delete. wp-framework v1.0.1 (rtCamp/wp-framework#82) restores the property and documents that exact pattern as the supported contract — so **no theme code changes are needed here**, only the pin and lock.

## The lock matters

`composer.lock` is committed and pinned `dev-main@e30352c`, so changing `composer.json` alone would break `composer install` in CI. Regenerated:

```
- Upgrading rtcamp/wp-framework (dev-main e30352c => v1.0.0)
- Upgrading rtcamp/wp-framework (v1.0.0 => v1.0.1)
```

Only that package moves.

## Deliberately unchanged

- `minimum-stability: dev` stays — other deps may rely on it; tightening it is a separate change.
- The `repositories` VCS block stays — wp-framework isn't on Packagist, so composer still needs the source even though the repo is public now.

## Note on the code delta

`dev-main@e30352c` predates the framework's audit fixes, so this pin also pulls in the crypto key derivation, asset path-traversal guards and feature-flag save fixes, and drops `XHProf_Profiler` (removed upstream — this theme doesn't reference it, checked).

---

## Also in here: a PHPStan config fix

`Lint PHP` was failing before this PR's own changes could be judged:

```
Invalid entry in excludePaths:
Path ".../node_modules" is neither a directory, nor a file path, nor a fnmatch pattern.
```

That job installs composer only — never npm — so `node_modules` doesn't exist and PHPStan treats the missing `excludePath` as a config error and refuses to run. Appending `(?)` marks it optional, which is what PHPStan's own error message recommends.

Unrelated to the dependency pin, and **pre-existing on `theme-elementary-v2` as well** — it surfaces now because the PHPStan job itself is new. Bundled here rather than split out so this PR can actually go green; merging it fixes the base branch too.

Verified locally both ways: 16 files at level 8, `[OK] No errors` with `node_modules` absent (CI) and present (dev).