### PR TITLE
fix: actually load the shared PHPStan baseline

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,5 +67,12 @@
 			"npm i"
 		],
 		"pot": "wp i18n make-pot . ./languages/elementary-theme.pot --domain=elementary-theme --include=\"inc,patterns,assets/build/js\""
+	},
+	"extra": {
+		"phpstan/extension-installer": {
+			"ignore": [
+				"szepeviktor/phpstan-wordpress"
+			]
+		}
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8144aae4b3fba46ff68b35fb66533700",
+    "content-hash": "15fc088e8f68ad6f81312546e67cdfbe",
     "packages": [
         {
             "name": "rtcamp/wp-framework",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,10 @@
 # https://phpstan.org/config-reference
+#
+# The shared baseline loads szepeviktor/phpstan-wordpress exactly once, so
+# composer.json tells extension-installer to ignore it. `level` below overrides
+# the baseline's 5.
 includes:
+	- vendor/rtcamp/wp-phpstan/phpstan.neon.dist
 	- phpstan-baseline.neon
 parameters:
 	# Rules


### PR DESCRIPTION
Follow-up to #748. That PR adopted `rtcamp/wp-phpstan`, but PHPStan was never actually reading it.

## The problem

`rtcamp/wp-phpstan` is `"type": "library"` with no `extra.phpstan` entry, so `phpstan/extension-installer` skips it:

```
> rtcamp/wp-phpstan: not supported
```

Nothing else pulled the config in — `phpstan.neon.dist` only included `phpstan-baseline.neon`. So requiring the package had no effect on analysis. #748 adopted the shared standard for PHPCS but, silently, not for PHPStan.

I got this wrong in #748: I assumed extension-installer auto-registered the package, and the values I checked to "confirm" it (`checkFunctionNameCase`, `treatPhpDocTypesAsCertain`) happened to be set identically in this repo's own config, so they proved nothing.

## The fix

Include the baseline explicitly, matching the package README and features-plugin-skeleton:

```neon
includes:
    - vendor/rtcamp/wp-phpstan/phpstan.neon.dist
    - phpstan-baseline.neon
```

The baseline includes `szepeviktor/phpstan-wordpress` itself and must load it exactly once, so extension-installer is told to ignore that package. Without the ignore, PHPStan fails on a duplicate include — which is what I ran into in #748 and mistakenly read as "the include is unnecessary".

## Verification

`level 8` still wins over the baseline's `5`:

```
$ vendor/bin/phpstan dump-parameters
level: 8
```

`composer phpstan` → `[OK] No errors`. `composer validate` → clean (lock content-hash updated for the `extra` addition; no package versions changed).