### PR TITLE
fix: stop running the scaffolder from the prepare hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
 		"lint:php:fix": "node ./bin/phpcbf.js",
 		"lint:staged": "lint-staged",
 		"pot": "composer run pot",
-		"prepare": "npm run init",
+		"prepare": "npm run sync-ai",
 		"pretest:php": "wp-env run cli --env-cwd=/var/www/html/wp-content/themes/${PWD##*/} composer install --no-interaction --no-scripts",
 		"start": "npm-run-all --parallel start:assets start:blocks",
 		"start:assets": "wp-scripts start  --experimental-modules --config webpack.config.js",


### PR DESCRIPTION
`npm` runs `prepare` on **every** install, and `composer.json` has `post-install-cmd: ["npm i"]`. So a plain `composer install` reaches `bin/init.js` — the interactive scaffolder that offers to delete `.git`:

```js
rl.question( 'Would you like to initialize git (Note: It will delete any `.git` folder already in current directory)? (y/n) ', ... )
...
fs.rmSync( gitDir, { recursive: true, force: true } );
```

There is no already-initialized guard, no TTY check and no CI check. CI escapes it only because every workflow passes `--no-scripts`.

### When it stops, and when it doesn't

`bin/init.js` *can* disarm itself, but only down the cleanup path. `themeCleanupQuestion()` → `updatePackageJson()` deletes `scripts.init` and strips `npm run init` out of `prepare`, and `updateComposerJson()` removes `post-install-cmd`.

That only happens if the developer answers **yes** to "Would you like to run the theme cleanup?". If they decline it, cancel at any earlier prompt, or `Ctrl-C`, the wiring stays and every later install re-prompts.

And if husky was installed along the way, `installHusky()` deliberately preserves the old `prepare` across husky's overwrite:

```js
execSync( 'npx husky init' );                                // prepare -> "husky"
packageJson.scripts.prepare += ` && ${ prepareScript }`;      // prepare -> "husky && npm run init"
```

so the scaffolder gets re-anchored into `prepare` rather than dropped.

Net: whether a clone stops prompting depends on which branch of an interactive flow the developer took. That is the wrong mechanism for deciding whether `composer install` is safe.

### Fix

```diff
-"prepare": "npm run init"
+"prepare": "npm run sync-ai"
```

`sync-ai` is the thing that genuinely needs to run after each install, and it exits 0 either way:

```
$ node bin/sync-ai.js          # framework present
AI instructions already in sync.
$ node bin/sync-ai.js          # fresh clone, no vendor/
sync-ai: rtcamp/wp-framework is not installed yet; run `composer install` first. Skipping.
```

The husky append above now yields `husky && npm run sync-ai`, which is correct. Scaffolding remains available as an explicit `npm run init`.

This matches features-plugin-skeleton, which keeps `init` out of `prepare`:

```
"prepare": "wp-tooling install-hooks || true && npm run sync-ai"
```

Migrating this repo's 629-line `bin/init.js` onto the shared `@rtcamp/wp-tooling` init engine is a follow-up — note that migration alone would **not** fix this, since the shared engine's `initRepo()` also removes `.git` unconditionally. The bug is the hook wiring, not the engine.